### PR TITLE
Refresh MiniMax provider endpoints

### DIFF
--- a/docs/cn/models/providers/index.md
+++ b/docs/cn/models/providers/index.md
@@ -87,9 +87,43 @@ Agently.set_settings("OpenAICompatible", {
 
 ## MiniMax
 
+MiniMax 同时提供全球站与中国站的 OpenAI 兼容和 Anthropic 兼容端点。
+
+OpenAI 兼容全球站端点：
+
 ```python
 Agently.set_settings("OpenAICompatible", {
-    "base_url": "https://api.minimax.chat/v1",
+    "base_url": "https://api.minimax.io/v1",
+    "api_key": "${ENV.MINIMAX_API_KEY}",
+    "model": "${ENV.MINIMAX_MODEL}",
+})
+```
+
+OpenAI 兼容中国站端点：
+
+```python
+Agently.set_settings("OpenAICompatible", {
+    "base_url": "https://api.minimaxi.com/v1",
+    "api_key": "${ENV.MINIMAX_API_KEY}",
+    "model": "${ENV.MINIMAX_MODEL}",
+})
+```
+
+Anthropic 兼容全球站端点：
+
+```python
+Agently.set_settings("AnthropicCompatible", {
+    "base_url": "https://api.minimax.io/anthropic/v1",
+    "api_key": "${ENV.MINIMAX_API_KEY}",
+    "model": "${ENV.MINIMAX_MODEL}",
+})
+```
+
+Anthropic 兼容中国站端点：
+
+```python
+Agently.set_settings("AnthropicCompatible", {
+    "base_url": "https://api.minimaxi.com/anthropic/v1",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })

--- a/docs/en/models/providers/index.md
+++ b/docs/en/models/providers/index.md
@@ -87,9 +87,43 @@ Agently.set_settings("OpenAICompatible", {
 
 ## MiniMax
 
+MiniMax provides OpenAI-compatible and Anthropic-compatible endpoints in both global and China regions.
+
+OpenAI-compatible global endpoint:
+
 ```python
 Agently.set_settings("OpenAICompatible", {
-    "base_url": "https://api.minimax.chat/v1",
+    "base_url": "https://api.minimax.io/v1",
+    "api_key": "${ENV.MINIMAX_API_KEY}",
+    "model": "${ENV.MINIMAX_MODEL}",
+})
+```
+
+OpenAI-compatible China endpoint:
+
+```python
+Agently.set_settings("OpenAICompatible", {
+    "base_url": "https://api.minimaxi.com/v1",
+    "api_key": "${ENV.MINIMAX_API_KEY}",
+    "model": "${ENV.MINIMAX_MODEL}",
+})
+```
+
+Anthropic-compatible global endpoint:
+
+```python
+Agently.set_settings("AnthropicCompatible", {
+    "base_url": "https://api.minimax.io/anthropic/v1",
+    "api_key": "${ENV.MINIMAX_API_KEY}",
+    "model": "${ENV.MINIMAX_MODEL}",
+})
+```
+
+Anthropic-compatible China endpoint:
+
+```python
+Agently.set_settings("AnthropicCompatible", {
+    "base_url": "https://api.minimaxi.com/anthropic/v1",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })


### PR DESCRIPTION
Reason: MiniMax provider docs use the legacy https://api.minimax.chat/v1 endpoint instead of the current MiniMax OpenAI-compatible endpoints.

## Summary
- Replace the legacy MiniMax provider endpoint with the current global and China OpenAI-compatible base URLs.
- Add matching MiniMax Anthropic-compatible examples using the required /anthropic/v1 path.
- Keep English and Chinese provider docs in sync.

## Test plan
- [x] git diff --check
- [x] Secret scan on the pending diff
- [x] python3 endpoint verification script

Generated with Claude Code.