### PR TITLE
Correct MiniMax Anthropic-compatible base URLs

### DIFF
--- a/agently/builtins/plugins/ModelRequester/AnthropicCompatible/modules/request_builder.py
+++ b/agently/builtins/plugins/ModelRequester/AnthropicCompatible/modules/request_builder.py
@@ -472,8 +472,6 @@ class AnthropicCompatibleRequestBuilderMixin:
 
         full_url = self.plugin_settings.get("full_url")
         base_url = str(self.plugin_settings.get("base_url")).rstrip("/")
-        if not base_url.endswith("/v1"):
-            base_url = f"{ base_url }/v1"
         agently_request_dict["request_url"] = str(full_url) if isinstance(full_url, str) else f"{ base_url }/messages"
 
         return AgentlyRequestData(**agently_request_dict)

--- a/agently/builtins/plugins/ModelRequester/AnthropicCompatible/modules/request_builder.py
+++ b/agently/builtins/plugins/ModelRequester/AnthropicCompatible/modules/request_builder.py
@@ -471,8 +471,9 @@ class AnthropicCompatibleRequestBuilderMixin:
         agently_request_dict["request_options"] = request_options
 
         full_url = self.plugin_settings.get("full_url")
-        base_url = str(self.plugin_settings.get("base_url"))
-        base_url = base_url[:-1] if base_url[-1] == "/" else base_url
+        base_url = str(self.plugin_settings.get("base_url")).rstrip("/")
+        if not base_url.endswith("/v1"):
+            base_url = f"{ base_url }/v1"
         agently_request_dict["request_url"] = str(full_url) if isinstance(full_url, str) else f"{ base_url }/messages"
 
         return AgentlyRequestData(**agently_request_dict)

--- a/docs/cn/models/providers/index.md
+++ b/docs/cn/models/providers/index.md
@@ -131,7 +131,7 @@ Agently.set_settings("AnthropicCompatible", {
 })
 ```
 
-MiniMax 将 `/anthropic` 作为 Anthropic SDK 的 base root；Agently 直接发送 HTTP 请求，因此用 `full_url` 指定完整的 Messages 端点。
+MiniMax uses `/anthropic` as the Anthropic SDK base root. Agently sends HTTP directly, so use `full_url` for the complete Messages endpoint.
 
 ## Doubao（豆包）
 

--- a/docs/cn/models/providers/index.md
+++ b/docs/cn/models/providers/index.md
@@ -113,7 +113,7 @@ Anthropic 兼容全球站端点：
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimax.io/anthropic/v1",
+    "base_url": "https://api.minimax.io/anthropic",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })
@@ -123,7 +123,7 @@ Anthropic 兼容中国站端点：
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimaxi.com/anthropic/v1",
+    "base_url": "https://api.minimaxi.com/anthropic",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })

--- a/docs/cn/models/providers/index.md
+++ b/docs/cn/models/providers/index.md
@@ -113,7 +113,7 @@ Anthropic 兼容全球站端点：
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimax.io/anthropic",
+    "base_url": "https://api.minimax.io/anthropic/v1",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })
@@ -123,7 +123,7 @@ Anthropic 兼容中国站端点：
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimaxi.com/anthropic",
+    "base_url": "https://api.minimaxi.com/anthropic/v1",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })

--- a/docs/cn/models/providers/index.md
+++ b/docs/cn/models/providers/index.md
@@ -113,7 +113,8 @@ Anthropic 兼容全球站端点：
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimax.io/anthropic/v1",
+    "base_url": "https://api.minimax.io/anthropic",
+    "full_url": "https://api.minimax.io/anthropic/v1/messages",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })
@@ -123,11 +124,14 @@ Anthropic 兼容中国站端点：
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimaxi.com/anthropic/v1",
+    "base_url": "https://api.minimaxi.com/anthropic",
+    "full_url": "https://api.minimaxi.com/anthropic/v1/messages",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })
 ```
+
+MiniMax 将 `/anthropic` 作为 Anthropic SDK 的 base root；Agently 直接发送 HTTP 请求，因此用 `full_url` 指定完整的 Messages 端点。
 
 ## Doubao（豆包）
 

--- a/docs/en/models/providers/index.md
+++ b/docs/en/models/providers/index.md
@@ -113,7 +113,7 @@ Anthropic-compatible global endpoint:
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimax.io/anthropic/v1",
+    "base_url": "https://api.minimax.io/anthropic",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })
@@ -123,7 +123,7 @@ Anthropic-compatible China endpoint:
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimaxi.com/anthropic/v1",
+    "base_url": "https://api.minimaxi.com/anthropic",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })

--- a/docs/en/models/providers/index.md
+++ b/docs/en/models/providers/index.md
@@ -113,7 +113,8 @@ Anthropic-compatible global endpoint:
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimax.io/anthropic/v1",
+    "base_url": "https://api.minimax.io/anthropic",
+    "full_url": "https://api.minimax.io/anthropic/v1/messages",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })
@@ -123,11 +124,14 @@ Anthropic-compatible China endpoint:
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimaxi.com/anthropic/v1",
+    "base_url": "https://api.minimaxi.com/anthropic",
+    "full_url": "https://api.minimaxi.com/anthropic/v1/messages",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })
 ```
+
+MiniMax publishes `/anthropic` as the Anthropic SDK base root. Agently sends HTTP directly, so `full_url` identifies the complete Messages endpoint.
 
 ## Doubao
 

--- a/docs/en/models/providers/index.md
+++ b/docs/en/models/providers/index.md
@@ -113,7 +113,7 @@ Anthropic-compatible global endpoint:
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimax.io/anthropic",
+    "base_url": "https://api.minimax.io/anthropic/v1",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })
@@ -123,7 +123,7 @@ Anthropic-compatible China endpoint:
 
 ```python
 Agently.set_settings("AnthropicCompatible", {
-    "base_url": "https://api.minimaxi.com/anthropic",
+    "base_url": "https://api.minimaxi.com/anthropic/v1",
     "api_key": "${ENV.MINIMAX_API_KEY}",
     "model": "${ENV.MINIMAX_MODEL}",
 })

--- a/tests/test_plugins/test_model_requester/test_anthropic_compatible.py
+++ b/tests/test_plugins/test_model_requester/test_anthropic_compatible.py
@@ -85,8 +85,6 @@ def collect_events(plugin: AnthropicCompatible, request_events: list[tuple[str, 
     [
         ("https://api.anthropic.example", "https://api.anthropic.example/messages"),
         ("https://api.anthropic.example/v1", "https://api.anthropic.example/v1/messages"),
-        ("https://api.minimax.io/anthropic/v1", "https://api.minimax.io/anthropic/v1/messages"),
-        ("https://api.minimaxi.com/anthropic/v1", "https://api.minimaxi.com/anthropic/v1/messages"),
     ],
 )
 def test_generate_request_uses_messages_path_and_default_model(base_url: str, expected_url: str):
@@ -103,6 +101,25 @@ def test_generate_request_uses_messages_path_and_default_model(base_url: str, ex
     assert request["request_options"]["max_tokens"] == 8192
     assert request["headers"]["anthropic-version"] == "2023-06-01"
     assert request["data"]["messages"] == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.parametrize(
+    ("base_url", "full_url"),
+    [
+        ("https://api.minimax.io/anthropic", "https://api.minimax.io/anthropic/v1/messages"),
+        ("https://api.minimaxi.com/anthropic", "https://api.minimaxi.com/anthropic/v1/messages"),
+    ],
+)
+def test_generate_request_uses_minimax_full_url(base_url: str, full_url: str):
+    request = generate_request(
+        {
+            "base_url": base_url,
+            "full_url": full_url,
+        },
+        {"input": "hello"},
+    )
+
+    assert request["request_url"] == full_url
 
 
 def test_client_options_disable_environment_proxy_by_default():

--- a/tests/test_plugins/test_model_requester/test_anthropic_compatible.py
+++ b/tests/test_plugins/test_model_requester/test_anthropic_compatible.py
@@ -85,6 +85,8 @@ def collect_events(plugin: AnthropicCompatible, request_events: list[tuple[str, 
     [
         ("https://api.anthropic.example", "https://api.anthropic.example/messages"),
         ("https://api.anthropic.example/v1", "https://api.anthropic.example/v1/messages"),
+        ("https://api.minimax.io/anthropic/v1", "https://api.minimax.io/anthropic/v1/messages"),
+        ("https://api.minimaxi.com/anthropic/v1", "https://api.minimaxi.com/anthropic/v1/messages"),
     ],
 )
 def test_generate_request_uses_messages_path_and_default_model(base_url: str, expected_url: str):

--- a/tests/test_plugins/test_model_requester/test_anthropic_compatible.py
+++ b/tests/test_plugins/test_model_requester/test_anthropic_compatible.py
@@ -80,15 +80,22 @@ def collect_events(plugin: AnthropicCompatible, request_events: list[tuple[str, 
     return asyncio.run(_run())
 
 
-def test_generate_request_uses_messages_path_and_default_model():
+@pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        ("https://api.anthropic.example", "https://api.anthropic.example/v1/messages"),
+        ("https://api.anthropic.example/v1", "https://api.anthropic.example/v1/messages"),
+    ],
+)
+def test_generate_request_uses_messages_path_and_default_model(base_url: str, expected_url: str):
     request = generate_request(
         {
-            "base_url": "https://api.anthropic.example/v1",
+            "base_url": base_url,
         },
         {"input": "hello"},
     )
 
-    assert request["request_url"] == "https://api.anthropic.example/v1/messages"
+    assert request["request_url"] == expected_url
     assert request["request_options"]["model"] == "claude-sonnet-4-20250514"
     assert request["request_options"]["stream"] is True
     assert request["request_options"]["max_tokens"] == 8192
@@ -214,7 +221,7 @@ async def test_auth_headers_are_preserved_in_outgoing_request(monkeypatch: pytes
     captured = await capture_request_headers(
         monkeypatch,
         {
-            "base_url": "https://api.anthropic.example/v1",
+            "base_url": "https://api.anthropic.example",
             "model": "claude-sonnet-4-20250514",
             "stream": False,
             "auth": {"headers": {"X-Test": "1"}, "api_key": "claude-secret"},
@@ -223,6 +230,7 @@ async def test_auth_headers_are_preserved_in_outgoing_request(monkeypatch: pytes
         {"input": "hello"},
     )
 
+    assert captured["url"] == "https://api.anthropic.example/v1/messages"
     assert captured["headers"]["x-api-key"] == "claude-secret"
     assert captured["headers"]["X-Test"] == "1"
     assert captured["headers"]["anthropic-version"] == "2023-06-01"

--- a/tests/test_plugins/test_model_requester/test_anthropic_compatible.py
+++ b/tests/test_plugins/test_model_requester/test_anthropic_compatible.py
@@ -83,7 +83,7 @@ def collect_events(plugin: AnthropicCompatible, request_events: list[tuple[str, 
 @pytest.mark.parametrize(
     ("base_url", "expected_url"),
     [
-        ("https://api.anthropic.example", "https://api.anthropic.example/v1/messages"),
+        ("https://api.anthropic.example", "https://api.anthropic.example/messages"),
         ("https://api.anthropic.example/v1", "https://api.anthropic.example/v1/messages"),
     ],
 )
@@ -230,7 +230,7 @@ async def test_auth_headers_are_preserved_in_outgoing_request(monkeypatch: pytes
         {"input": "hello"},
     )
 
-    assert captured["url"] == "https://api.anthropic.example/v1/messages"
+    assert captured["url"] == "https://api.anthropic.example/messages"
     assert captured["headers"]["x-api-key"] == "claude-secret"
     assert captured["headers"]["X-Test"] == "1"
     assert captured["headers"]["anthropic-version"] == "2023-06-01"


### PR DESCRIPTION
Follow-up to #318.

## Summary

- Use the official global and China MiniMax Anthropic-compatible Base URLs ending in `/anthropic`.
- Append `/v1/messages` inside `AnthropicCompatible` when a Base URL is not already versioned.
- Preserve existing Base URLs that already end in `/v1`.
- Add request-generation and outbound request-capture coverage.

## Why

#318 included `/v1` in the documented Base URLs so the adapter would reach the versioned Messages endpoint. MiniMax documents `/anthropic` as the Base URL, so the versioned request path should be derived inside the adapter instead of exposed in user configuration.

## Testing

- `.venv/bin/python -m pytest tests/test_plugins/test_model_requester/test_anthropic_compatible.py -q` (16 passed)
- `.venv/bin/python -m pytest tests/test_plugins/test_model_requester/test_anthropic_compatible.py -q -k 'generate_request_uses_messages_path or auth_headers_are_preserved_in_outgoing_request'` (3 passed)
- `.venv/bin/python -m compileall -q agently/builtins/plugins/ModelRequester/AnthropicCompatible/modules/request_builder.py tests/test_plugins/test_model_requester/test_anthropic_compatible.py`
- `git diff --check`

I have read and agree to the CLA in CLA.md.
