### PR TITLE
Feature/add sandbox plugin

### DIFF
--- a/agently/_default_init.py
+++ b/agently/_default_init.py
@@ -33,6 +33,7 @@ def _load_default_plugins(plugin_manager: "PluginManager"):
         MCPActionExecutor,
         NodeJSActionExecutor,
         PythonSandboxActionExecutor,
+        SandboxActionExecutor,
         SQLiteActionExecutor,
         SearchActionExecutor,
     )
@@ -59,6 +60,7 @@ def _load_default_plugins(plugin_manager: "PluginManager"):
     plugin_manager.register("ActionExecutor", NodeJSActionExecutor, activate=False)
     plugin_manager.register("ActionExecutor", CodeRuntimeActionExecutor, activate=False)
     plugin_manager.register("ActionExecutor", DockerActionExecutor, activate=False)
+    plugin_manager.register("ActionExecutor", SandboxActionExecutor, activate=False)
     plugin_manager.register("ActionExecutor", SQLiteActionExecutor, activate=False)
     plugin_manager.register("ExecutionResourceProvider", ACPExecutionResourceProvider, activate=False)
     plugin_manager.register("ExecutionResourceProvider", MCPExecutionResourceProvider, activate=False)

--- a/agently/builtins/plugins/ActionExecutor/DockerActionExecutor.py
+++ b/agently/builtins/plugins/ActionExecutor/DockerActionExecutor.py
@@ -17,14 +17,36 @@ from typing import Any
 
 class DockerActionExecutor:
     name = "DockerActionExecutor"
-    DEFAULT_SETTINGS = {}
+    DEFAULT_SETTINGS = {
+        "$global": {
+            "sandbox.docker_binary": "docker",
+            "sandbox.default_timeout": 60,
+            "sandbox.default_image": "python:3.12-slim",
+            "sandbox.network_mode": "disabled",
+            "sandbox.memory": "512m",
+            "sandbox.cpus": "1",
+        },
+    }
 
     kind = "docker"
     sandboxed = True
 
-    def __init__(self, *, image: str | None = None, timeout: int = 60):
+    def __init__(
+        self,
+        *,
+        image: str | None = None,
+        timeout: int = 60,
+        docker_binary: str = "docker",
+        network_mode: str = "disabled",
+        memory: str = "512m",
+        cpus: str = "1",
+    ):
         self.image = image
         self.timeout = timeout
+        self.docker_binary = docker_binary
+        self.network_mode = network_mode
+        self.memory = memory
+        self.cpus = cpus
 
     @staticmethod
     def _on_register():
@@ -35,7 +57,6 @@ class DockerActionExecutor:
         pass
 
     async def execute(self, *, spec, action_call, policy, settings) -> Any:
-        _ = settings
         action_input = action_call.get("action_input", {})
         if not isinstance(action_input, dict):
             action_input = {}
@@ -49,6 +70,8 @@ class DockerActionExecutor:
             cmd = str(command)
         action_id = str(spec.get("action_id", "run_docker"))
         timeout = int(policy.get("timeout_seconds", self.timeout))
+
+        # Path 1: Use ExecutionResourceProvider if available (existing behaviour)
         environment_resources = action_call.get("execution_resource_resources", {})
         if isinstance(environment_resources, dict):
             docker_resource = environment_resources.get(action_id) or environment_resources.get("docker")
@@ -60,7 +83,53 @@ class DockerActionExecutor:
                     env=action_input.get("env"),
                     timeout=timeout,
                 )
-        return {
-            "ok": False,
-            "error": "Docker execution environment resource is not available.",
-        }
+
+        # Path 2: Fallback — directly manage Docker containers via subprocess
+        from agently.builtins.plugins.ExecutionResourceProvider.DockerExecutionResourceProvider import (
+            DockerExecutionResource,
+        )
+
+        docker_binary = str(settings.get("sandbox.docker_binary", self.docker_binary)) if settings else self.docker_binary
+        network_mode = str(settings.get("sandbox.network_mode", self.network_mode)) if settings else self.network_mode
+        memory = str(settings.get("sandbox.memory", self.memory)) if settings else self.memory
+        cpus = str(settings.get("sandbox.cpus", self.cpus)) if settings else self.cpus
+
+        fallback_resource = DockerExecutionResource(
+            docker_binary=docker_binary,
+            timeout=timeout,
+            runtime_profile={
+                "network_mode": network_mode,
+                "memory": memory,
+                "cpus": cpus,
+                "provisioning_profile": "strict",
+            },
+        )
+        if not fallback_resource.is_binary_available():
+            return {
+                "ok": False,
+                "error": (
+                    f"Docker execution resource is not available and Docker "
+                    f"binary '{docker_binary}' not found."
+                ),
+            }
+
+        # Detect python_code input and route to run_python_code
+        python_code = action_input.get("python_code")
+        if python_code and not action_input.get("cmd") and not action_input.get("command"):
+            return await fallback_resource.run_python_code(
+                python_code=str(python_code),
+                timeout=timeout,
+            )
+
+        # Default: resolve image from settings if not specified
+        if not image:
+            default_image = str(settings.get("sandbox.default_image", "python:3.12-slim")) if settings else "python:3.12-slim"
+            image = default_image
+
+        return await fallback_resource.run(
+            image=image,
+            cmd=cmd,
+            workdir=action_input.get("workdir"),
+            env=action_input.get("env"),
+            timeout=timeout,
+        )

--- a/agently/builtins/plugins/ActionExecutor/SandboxActionExecutor.py
+++ b/agently/builtins/plugins/ActionExecutor/SandboxActionExecutor.py
@@ -1,0 +1,231 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+SandboxActionExecutor — unified sandbox ActionExecutor plugin.
+
+Replaces the legacy PythonSandboxActionExecutor and BashSandboxActionExecutor
+with a real isolated sandbox backend (Docker / gVisor).
+
+This executor integrates with Agently's plugin system via the ActionExecutor
+protocol and provides pluggable backend selection through settings.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from agently.builtins.sandbox.protocol import IsolationLevel, SandboxConfig, SandboxResult
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxActionExecutor:
+    """
+    Unified sandbox ActionExecutor plugin with pluggable backends.
+
+    This replaces the fake sandbox executors (PythonSandbox, BashSandbox) with
+    real container isolation.  The backend is selected via settings:
+
+    - ``sandbox.backend``: ``"docker"`` (default) or ``"gvisor"``
+    - ``sandbox.network_enabled``: ``False`` (default)
+    - ``sandbox.block_cloud_metadata``: ``True`` (default)
+
+    The executor first checks ``execution_resource_resources`` for backward
+    compatibility with the existing ExecutionResourceProvider chain.  If no
+    external resource is available, it falls back to its own backend management.
+    """
+
+    name = "SandboxActionExecutor"
+    DEFAULT_SETTINGS = {
+        "$global": {
+            "sandbox.backend": "docker",
+            "sandbox.default_isolation": "container",
+            "sandbox.default_timeout": 30,
+            "sandbox.default_memory_limit": "512m",
+            "sandbox.default_image": "python:3.12-slim",
+            "sandbox.network_enabled": False,
+            "sandbox.block_cloud_metadata": True,
+            "sandbox.docker_binary": "docker",
+            "sandbox.pool_min": 1,
+            "sandbox.pool_max": 10,
+        },
+    }
+
+    kind = "sandbox"
+    sandboxed = True  # This time it's real!
+
+    def __init__(
+        self,
+        *,
+        backend: str = "docker",
+        docker_binary: str = "docker",
+        default_image: str = "python:3.12-slim",
+        default_timeout: int = 30,
+        network_enabled: bool = False,
+        block_cloud_metadata: bool = True,
+        pool_min: int = 1,
+        pool_max: int = 10,
+    ):
+        self._backend_name = backend
+        self._docker_binary = docker_binary
+        self._default_image = default_image
+        self._default_timeout = default_timeout
+        self._network_enabled = network_enabled
+        self._block_cloud_metadata = block_cloud_metadata
+        self._pool_min = pool_min
+        self._pool_max = pool_max
+        self._backend: Any = None
+        self._sessions: dict[str, Any] = {}
+
+    @staticmethod
+    def _on_register():
+        pass
+
+    @staticmethod
+    def _on_unregister():
+        pass
+
+    def _get_backend(self) -> Any:
+        """Lazy-initialize the sandbox backend."""
+        if self._backend is not None:
+            return self._backend
+
+        if self._backend_name == "gvisor":
+            from agently.builtins.sandbox.gvisor_backend import GVisorSandboxBackend
+
+            self._backend = GVisorSandboxBackend(
+                docker_binary=self._docker_binary,
+                pool_min=self._pool_min,
+                pool_max=self._pool_max,
+            )
+        else:
+            from agently.builtins.sandbox.docker_backend import DockerSandboxBackend
+
+            self._backend = DockerSandboxBackend(
+                docker_binary=self._docker_binary,
+                pool_min=self._pool_min,
+                pool_max=self._pool_max,
+            )
+        return self._backend
+
+    def _build_config(self, policy: dict[str, Any], settings: Any) -> SandboxConfig:
+        """Merge settings and policy into a SandboxConfig."""
+        image = self._default_image
+        timeout = self._default_timeout
+        memory_limit = "512m"
+        network_enabled = self._network_enabled
+
+        if settings:
+            image = str(settings.get("sandbox.default_image", image))
+            timeout = int(settings.get("sandbox.default_timeout", timeout))
+            memory_limit = str(settings.get("sandbox.default_memory_limit", memory_limit))
+            network_enabled = bool(settings.get("sandbox.network_enabled", network_enabled))
+
+        # Policy overrides
+        if isinstance(policy, dict):
+            timeout = int(policy.get("timeout_seconds", timeout))
+            image = str(policy.get("sandbox_image", image))
+            memory_limit = str(policy.get("sandbox_memory", memory_limit))
+            if "network_enabled" in policy:
+                network_enabled = bool(policy["network_enabled"])
+
+        return SandboxConfig(
+            image=image,
+            timeout=timeout,
+            memory_limit=memory_limit,
+            network_enabled=network_enabled,
+            block_cloud_metadata=self._block_cloud_metadata,
+        )
+
+    async def execute(self, *, spec, action_call, policy, settings) -> Any:
+        """
+        Execute an action inside a real sandbox container.
+
+        Flow:
+        1. Check execution_resource_resources (backward compat)
+        2. Build SandboxConfig from settings + policy
+        3. Create or reuse sandbox session
+        4. Route to execute() or execute_python() based on action_input
+        5. Return standardized result
+        """
+        action_input = action_call.get("action_input", {})
+        if not isinstance(action_input, dict):
+            action_input = {}
+
+        action_id = str(spec.get("action_id", "sandbox"))
+        timeout = int(policy.get("timeout_seconds", self._default_timeout)) if isinstance(policy, dict) else self._default_timeout
+
+        # Path 1: backward-compatible ExecutionResourceProvider delegation
+        environment_resources = action_call.get("execution_resource_resources", {})
+        if isinstance(environment_resources, dict):
+            resource = environment_resources.get(action_id) or environment_resources.get("sandbox") or environment_resources.get("docker")
+            if resource is not None and hasattr(resource, "run"):
+                image = str(action_input.get("image") or self._default_image)
+                command = action_input.get("cmd", action_input.get("command", []))
+                return await resource.run(
+                    image=image,
+                    cmd=command,
+                    workdir=action_input.get("workdir"),
+                    env=action_input.get("env"),
+                    timeout=timeout,
+                )
+
+        # Path 2: native sandbox backend
+        config = self._build_config(policy if isinstance(policy, dict) else {}, settings)
+        config.timeout = timeout
+
+        backend = self._get_backend()
+
+        # Get or create session (reuse for same action_id within the agent run)
+        session_key = action_id
+        session = self._sessions.get(session_key)
+        if session is None:
+            try:
+                session = await backend.create_session(config)
+                self._sessions[session_key] = session
+            except RuntimeError as exc:
+                return {
+                    "ok": False,
+                    "error": str(exc),
+                    "sandbox_backend": self._backend_name,
+                }
+
+        # Route based on action_input type
+        python_code = action_input.get("python_code")
+        if python_code and not action_input.get("cmd") and not action_input.get("command"):
+            result = await session.execute_python(
+                str(python_code),
+                timeout=timeout,
+            )
+        else:
+            command = action_input.get("cmd", action_input.get("command", ""))
+            if isinstance(command, list):
+                command = " ".join(str(item) for item in command)
+            result = await session.execute(
+                str(command),
+                timeout=timeout,
+            )
+
+        return {
+            "ok": result.success,
+            "exit_code": result.exit_code,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "execution_time_ms": result.execution_time_ms,
+            "sandbox_id": result.sandbox_id,
+            "sandbox_backend": self._backend_name,
+            "truncated": result.truncated,
+        }

--- a/agently/builtins/plugins/ActionExecutor/__init__.py
+++ b/agently/builtins/plugins/ActionExecutor/__init__.py
@@ -7,4 +7,5 @@ from .BrowseActionExecutor import BrowseActionExecutor
 from .NodeJSActionExecutor import NodeJSActionExecutor
 from .CodeRuntimeActionExecutor import CodeRuntimeActionExecutor
 from .DockerActionExecutor import DockerActionExecutor
+from .SandboxActionExecutor import SandboxActionExecutor
 from .SQLiteActionExecutor import SQLiteActionExecutor

--- a/agently/builtins/sandbox/__init__.py
+++ b/agently/builtins/sandbox/__init__.py
@@ -1,0 +1,36 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Pluggable sandbox backends for real Agent code execution isolation.
+
+Provides SandboxBackend / SandboxSession protocols and concrete implementations
+(Docker, gVisor) that replace the legacy fake-sandbox executors.
+"""
+
+from .protocol import (
+    IsolationLevel,
+    SandboxBackend,
+    SandboxConfig,
+    SandboxResult,
+    SandboxSession,
+)
+
+__all__ = [
+    "IsolationLevel",
+    "SandboxBackend",
+    "SandboxConfig",
+    "SandboxResult",
+    "SandboxSession",
+]

--- a/agently/builtins/sandbox/docker_backend.py
+++ b/agently/builtins/sandbox/docker_backend.py
@@ -1,0 +1,520 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Docker sandbox backend.
+
+Provides real container-based isolation using Docker CLI (subprocess).
+Container pool management is inspired by graph-flow's DockerSandboxManager
+(acquire/release pattern) but adapted for Agently's async-first architecture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shlex
+import shutil
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from .protocol import IsolationLevel, SandboxConfig, SandboxResult
+
+
+# ---------------------------------------------------------------------------
+# Container handle — tracks a single running container
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _ContainerHandle:
+    """Internal handle for a running sandbox container."""
+
+    container_id: str
+    image: str
+    session_id: str
+    created_at: float = field(default_factory=time.time)
+    last_used: float = field(default_factory=time.time)
+    is_healthy: bool = True
+
+
+# ---------------------------------------------------------------------------
+# DockerSandboxSession — one isolated execution session
+# ---------------------------------------------------------------------------
+
+class DockerSandboxSession:
+    """
+    A single Docker sandbox session wrapping one running container.
+
+    Given a container_id and Docker binary
+    When execute() is called
+    Then the command runs inside the isolated container via ``docker exec``
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        container_id: str,
+        docker_binary: str,
+        image: str,
+        config: SandboxConfig,
+    ):
+        self.session_id = session_id
+        self.backend_name = "DockerSandbox"
+        self.isolation_level = IsolationLevel.CONTAINER
+        self._container_id = container_id
+        self._docker_binary = docker_binary
+        self._image = image
+        self._config = config
+
+    async def execute(self, command: str, *, timeout: int | None = None) -> SandboxResult:
+        """Execute a shell command inside the container."""
+        effective_timeout = timeout or self._config.timeout
+        start = time.monotonic()
+
+        escaped = command.replace("\\", "\\\\").replace('"', '\\"')
+        shell_cmd = f'sh -c "{escaped}"'
+
+        result = await asyncio.to_thread(
+            self._run_docker_exec,
+            shell_cmd,
+            effective_timeout,
+        )
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        return SandboxResult(
+            exit_code=result.get("exit_code", 1),
+            stdout=result.get("stdout", ""),
+            stderr=result.get("stderr", ""),
+            execution_time_ms=elapsed_ms,
+            sandbox_id=self._container_id,
+            truncated=result.get("truncated", False),
+        )
+
+    async def execute_python(self, code: str, *, timeout: int | None = None) -> SandboxResult:
+        """Execute Python code inside the container."""
+        effective_timeout = timeout or self._config.timeout
+        start = time.monotonic()
+
+        # Write code to a temp file inside the container and execute it
+        wrapped_cmd = (
+            f"python -c {shlex.quote(code)}"
+        )
+
+        result = await asyncio.to_thread(
+            self._run_docker_exec,
+            f'sh -c {shlex.quote(wrapped_cmd)}',
+            effective_timeout,
+        )
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        return SandboxResult(
+            exit_code=result.get("exit_code", 1),
+            stdout=result.get("stdout", ""),
+            stderr=result.get("stderr", ""),
+            execution_time_ms=elapsed_ms,
+            sandbox_id=self._container_id,
+            truncated=result.get("truncated", False),
+        )
+
+    async def read_file(self, path: str) -> bytes:
+        """Read a file from the container."""
+        result = await asyncio.to_thread(
+            self._run_docker_exec,
+            f'cat {shlex.quote(path)}',
+            10,
+        )
+        if result.get("exit_code", 1) != 0:
+            raise FileNotFoundError(f"Cannot read {path}: {result.get('stderr', '')}")
+        return result.get("stdout", "").encode("utf-8")
+
+    async def write_file(self, path: str, content: bytes) -> None:
+        """Write a file to the container via docker exec."""
+        import base64
+
+        b64 = base64.b64encode(content).decode("ascii")
+        cmd = f'echo {b64} | base64 -d > {shlex.quote(path)}'
+        result = await asyncio.to_thread(self._run_docker_exec, cmd, 10)
+        if result.get("exit_code", 1) != 0:
+            raise OSError(f"Cannot write {path}: {result.get('stderr', '')}")
+
+    async def list_files(self, path: str) -> list[dict[str, Any]]:
+        """List files in a directory inside the container."""
+        cmd = f'ls -la --json {shlex.quote(path)} 2>/dev/null || ls -la {shlex.quote(path)}'
+        result = await asyncio.to_thread(self._run_docker_exec, cmd, 10)
+        stdout = result.get("stdout", "")
+        # Parse simple ls output into list of dicts
+        entries: list[dict[str, Any]] = []
+        for line in stdout.strip().splitlines():
+            if line.startswith("total "):
+                continue
+            entries.append({"raw": line})
+        return entries
+
+    async def get_status(self) -> dict[str, Any]:
+        """Get container status."""
+        result = await asyncio.to_thread(
+            self._run_docker_cmd,
+            ["inspect", "--format", "{{.State.Status}}", self._container_id],
+            5,
+        )
+        return {
+            "session_id": self.session_id,
+            "container_id": self._container_id,
+            "status": result.get("stdout", "unknown").strip(),
+            "backend": self.backend_name,
+        }
+
+    async def close(self) -> None:
+        """Stop and remove the container."""
+        await asyncio.to_thread(
+            self._run_docker_cmd,
+            ["stop", "-t", "5", self._container_id],
+            15,
+        )
+        await asyncio.to_thread(
+            self._run_docker_cmd,
+            ["rm", "-f", self._container_id],
+            10,
+        )
+
+    # -- internal helpers --
+
+    def _run_docker_exec(self, cmd: str, timeout: int) -> dict[str, Any]:
+        """Synchronous docker exec (runs in thread)."""
+        import subprocess
+
+        args = [
+            self._docker_binary, "exec",
+            self._container_id,
+            "sh", "-c", cmd,
+        ]
+        try:
+            proc = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return {
+                "exit_code": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            }
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout.decode("utf-8", errors="replace") if isinstance(exc.stdout, bytes) else str(exc.stdout or "")
+            stderr = exc.stderr.decode("utf-8", errors="replace") if isinstance(exc.stderr, bytes) else str(exc.stderr or "")
+            return {
+                "exit_code": -1,
+                "stdout": stdout,
+                "stderr": stderr or "Command timed out",
+                "truncated": True,
+            }
+        except Exception as exc:
+            return {
+                "exit_code": 1,
+                "stdout": "",
+                "stderr": str(exc),
+            }
+
+    def _run_docker_cmd(self, sub_args: list[str], timeout: int) -> dict[str, Any]:
+        """Synchronous docker CLI call (runs in thread)."""
+        import subprocess
+
+        args = [self._docker_binary, *sub_args]
+        try:
+            proc = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return {
+                "exit_code": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            }
+        except Exception as exc:
+            return {
+                "exit_code": 1,
+                "stdout": "",
+                "stderr": str(exc),
+            }
+
+
+# ---------------------------------------------------------------------------
+# DockerSandboxBackend — manages sessions and container pool
+# ---------------------------------------------------------------------------
+
+class DockerSandboxBackend:
+    """
+    Docker sandbox backend with container pool management.
+
+    Given a SandboxConfig
+    When create_session is called
+    Then an existing idle container is reused from the pool, or a new one is created
+    When destroy_session is called
+    Then the container is returned to the pool or destroyed
+
+    Pool strategy (inspired by graph-flow DockerSandboxManager):
+    - _pool: idle containers available for reuse
+    - _active: containers currently in use
+    - pool_min / pool_max / idle_timeout control sizing
+    """
+
+    name = "DockerSandbox"
+    supported_isolation_levels = [IsolationLevel.CONTAINER]
+
+    def __init__(
+        self,
+        *,
+        docker_binary: str = "docker",
+        pool_min: int = 1,
+        pool_max: int = 10,
+        idle_timeout: int = 300,
+    ):
+        self._docker_binary = docker_binary
+        self._pool_min = pool_min
+        self._pool_max = pool_max
+        self._idle_timeout = idle_timeout
+
+        self._pool: list[_ContainerHandle] = []
+        self._active: dict[str, _ContainerHandle] = {}
+        self._lock = asyncio.Lock()
+        self._docker_available: bool | None = None
+
+    # -- SandboxBackend protocol --
+
+    async def create_session(self, config: SandboxConfig) -> DockerSandboxSession:
+        """Create or reuse a sandbox session."""
+        if self._docker_available is None:
+            self._docker_available = await self._check_docker()
+        if not self._docker_available:
+            raise RuntimeError(
+                f"Docker binary '{self._docker_binary}' is not available. "
+                "Ensure Docker is installed and the daemon is running."
+            )
+
+        session_id = f"sandbox-{uuid.uuid4().hex[:12]}"
+
+        async with self._lock:
+            # Try to reuse an idle container from the pool
+            handle = self._find_idle_container(config.image)
+            if handle is not None:
+                handle.session_id = session_id
+                handle.last_used = time.time()
+                self._active[session_id] = handle
+            else:
+                # Create a new container
+                if len(self._active) + len(self._pool) >= self._pool_max:
+                    await self._shrink_pool()
+                container_id = await self._create_container(config, session_id)
+                handle = _ContainerHandle(
+                    container_id=container_id,
+                    image=config.image,
+                    session_id=session_id,
+                )
+                self._active[session_id] = handle
+
+        return DockerSandboxSession(
+            session_id=session_id,
+            container_id=handle.container_id,
+            docker_binary=self._docker_binary,
+            image=config.image,
+            config=config,
+        )
+
+    async def destroy_session(self, session_id: str) -> None:
+        """Destroy a sandbox session — return container to pool or destroy."""
+        async with self._lock:
+            handle = self._active.pop(session_id, None)
+            if handle is None:
+                return
+
+            handle.session_id = ""
+            handle.last_used = time.time()
+
+            if len(self._pool) < self._pool_min:
+                # Return to pool for reuse
+                self._pool.append(handle)
+            else:
+                # Pool is full, destroy the container
+                await self._destroy_container(handle)
+
+    async def list_sessions(self) -> list[str]:
+        """List active session IDs."""
+        async with self._lock:
+            return list(self._active.keys())
+
+    async def health_check(self) -> dict[str, Any]:
+        """Check backend health."""
+        available = await self._check_docker()
+        async with self._lock:
+            return {
+                "backend": self.name,
+                "healthy": available,
+                "docker_available": available,
+                "active_sessions": len(self._active),
+                "idle_containers": len(self._pool),
+                "pool_max": self._pool_max,
+            }
+
+    def capabilities(self) -> dict[str, Any]:
+        """Return backend capabilities."""
+        return {
+            "backend": self.name,
+            "isolation_levels": [lvl.value for lvl in self.supported_isolation_levels],
+            "network_control": True,
+            "gpu_support": False,
+            "read_only_fs": True,
+            "resource_limits": True,
+        }
+
+    # -- internal methods --
+
+    async def _check_docker(self) -> bool:
+        """Check if Docker is available."""
+        def _check() -> bool:
+            if shutil.which(self._docker_binary) is None:
+                return False
+            import subprocess
+            try:
+                result = subprocess.run(
+                    [self._docker_binary, "version", "--format", "{{.Server.Version}}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                return result.returncode == 0
+            except Exception:
+                return False
+
+        return await asyncio.to_thread(_check)
+
+    def _find_idle_container(self, image: str) -> _ContainerHandle | None:
+        """Find an idle container matching the requested image."""
+        for handle in self._pool:
+            if handle.image == image and handle.is_healthy:
+                self._pool.remove(handle)
+                return handle
+        return None
+
+    async def _create_container(self, config: SandboxConfig, session_id: str) -> str:
+        """Create and start a new Docker container with security hardening."""
+        container_name = f"agently-sandbox-{session_id}"
+
+        args = [
+            self._docker_binary, "run", "-d",
+            "--name", container_name,
+            "--label", "agently.sandbox=true",
+            "--label", f"agently.session={session_id}",
+        ]
+
+        # Resource limits
+        args.extend(["--memory", config.memory_limit])
+        cpu_period = 100000
+        cpu_quota = int(cpu_period * config.cpu_limit)
+        args.extend(["--cpu-period", str(cpu_period), "--cpu-quota", str(cpu_quota)])
+
+        # Security hardening
+        args.extend(["--security-opt", "no-new-privileges:true"])
+        if config.drop_capabilities:
+            args.extend(["--cap-drop", "ALL"])
+        args.extend(["--user", f"{config.run_as_user}:{config.run_as_user}"])
+
+        # Filesystem
+        if config.read_only_fs:
+            args.append("--read-only")
+        args.extend([
+            "--tmpfs", f"/tmp:size={config.writable_tmp_size},noexec,nosuid",
+        ])
+
+        # Network
+        if not config.network_enabled:
+            args.extend(["--network", "none"])
+
+        # GPU support
+        if config.gpu_enabled and config.gpu_device_ids:
+            device_ids = ",".join(str(i) for i in config.gpu_device_ids)
+            args.extend([
+                "--gpus", f'"device={device_ids}"',
+            ])
+
+        # Volume mounts
+        for host_path, container_path in config.mount_volumes.items():
+            args.extend(["-v", f"{host_path}:{container_path}"])
+
+        # Image and keep-alive command
+        args.append(config.image)
+        args.extend(["sleep", "infinity"])
+
+        result = await asyncio.to_thread(self._subprocess_run, args, 30)
+        if result.get("exit_code", 1) != 0:
+            raise RuntimeError(
+                f"Failed to create sandbox container: {result.get('stderr', 'unknown error')}"
+            )
+
+        container_id = result.get("stdout", "").strip()
+        if not container_id:
+            raise RuntimeError("Failed to get container ID after creation")
+        return container_id[:12]
+
+    async def _destroy_container(self, handle: _ContainerHandle) -> None:
+        """Stop and remove a container."""
+        await asyncio.to_thread(
+            self._subprocess_run,
+            [self._docker_binary, "stop", "-t", "5", handle.container_id],
+            15,
+        )
+        await asyncio.to_thread(
+            self._subprocess_run,
+            [self._docker_binary, "rm", "-f", handle.container_id],
+            10,
+        )
+
+    async def _shrink_pool(self) -> None:
+        """Remove expired idle containers from the pool."""
+        now = time.time()
+        expired = [
+            h for h in self._pool
+            if now - h.last_used > self._idle_timeout
+        ]
+        for handle in expired:
+            if len(self._pool) > self._pool_min:
+                self._pool.remove(handle)
+                await self._destroy_container(handle)
+
+    @staticmethod
+    def _subprocess_run(args: list[str], timeout: int) -> dict[str, Any]:
+        """Run a subprocess command synchronously."""
+        import subprocess
+
+        try:
+            proc = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return {
+                "exit_code": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            }
+        except subprocess.TimeoutExpired:
+            return {"exit_code": -1, "stdout": "", "stderr": "Command timed out"}
+        except Exception as exc:
+            return {"exit_code": 1, "stdout": "", "stderr": str(exc)}

--- a/agently/builtins/sandbox/events.py
+++ b/agently/builtins/sandbox/events.py
@@ -1,0 +1,185 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Sandbox event emission.
+
+Emits RuntimeEvents for sandbox lifecycle and execution, integrating with
+Agently's EventCenter for observability and traceability.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agently.types.data.event import RuntimeEvent
+
+
+# ---------------------------------------------------------------------------
+# Sandbox event types
+# ---------------------------------------------------------------------------
+
+SANDBOX_EVENT_TYPES: dict[str, str] = {
+    "sandbox.session_created": "Sandbox session created",
+    "sandbox.execution_started": "Command execution started",
+    "sandbox.execution_completed": "Command execution completed",
+    "sandbox.execution_failed": "Command execution failed",
+    "sandbox.execution_timeout": "Command execution timed out",
+    "sandbox.policy_violation": "Security policy violation (command blocked)",
+    "sandbox.network_blocked": "Network request blocked",
+    "sandbox.session_destroyed": "Sandbox session destroyed",
+}
+
+
+# ---------------------------------------------------------------------------
+# Event emission helpers
+# ---------------------------------------------------------------------------
+
+async def emit_sandbox_event(
+    event_type: str,
+    *,
+    session_id: str,
+    backend_name: str,
+    isolation_level: str = "container",
+    command: str | None = None,
+    result: Any | None = None,
+    policy_violation: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> RuntimeEvent:
+    """
+    Create a sandbox RuntimeEvent.
+
+    Returns the event object.  Callers are responsible for dispatching it
+    through the EventCenter (or logging it directly).
+
+    Args:
+        event_type: One of the SANDBOX_EVENT_TYPES keys.
+        session_id: The sandbox session identifier.
+        backend_name: The sandbox backend name (e.g. "DockerSandbox").
+        isolation_level: The isolation level string.
+        command: The command that was executed (if applicable).
+        result: The SandboxResult (if applicable).
+        policy_violation: Description of the policy violation (if applicable).
+        extra: Additional payload data.
+
+    Returns:
+        A RuntimeEvent ready for dispatch.
+    """
+    payload: dict[str, Any] = {
+        "session_id": session_id,
+        "isolation_level": isolation_level,
+    }
+
+    if command is not None:
+        payload["command"] = command
+
+    if result is not None:
+        if hasattr(result, "to_dict"):
+            payload["result"] = result.to_dict()
+        elif isinstance(result, dict):
+            payload["result"] = result
+        else:
+            payload["result"] = str(result)
+
+    if policy_violation is not None:
+        payload["policy_violation"] = policy_violation
+
+    if extra:
+        payload.update(extra)
+
+    level = "INFO"
+    if "failed" in event_type or "violation" in event_type or "blocked" in event_type:
+        level = "WARNING"
+    elif "timeout" in event_type:
+        level = "WARNING"
+
+    return RuntimeEvent(
+        event_type=event_type,
+        source=f"SandboxBackend:{backend_name}",
+        level=level,
+        message=SANDBOX_EVENT_TYPES.get(event_type, event_type),
+        payload=payload,
+        meta={
+            "sandbox_backend": backend_name,
+            "sandboxed": True,
+        },
+    )
+
+
+async def emit_session_created(
+    *,
+    session_id: str,
+    backend_name: str,
+    isolation_level: str = "container",
+    image: str = "",
+) -> RuntimeEvent:
+    """Emit a session-created event."""
+    return await emit_sandbox_event(
+        "sandbox.session_created",
+        session_id=session_id,
+        backend_name=backend_name,
+        isolation_level=isolation_level,
+        extra={"image": image},
+    )
+
+
+async def emit_execution_completed(
+    *,
+    session_id: str,
+    backend_name: str,
+    isolation_level: str = "container",
+    command: str | None = None,
+    result: Any | None = None,
+) -> RuntimeEvent:
+    """Emit an execution-completed event."""
+    return await emit_sandbox_event(
+        "sandbox.execution_completed",
+        session_id=session_id,
+        backend_name=backend_name,
+        isolation_level=isolation_level,
+        command=command,
+        result=result,
+    )
+
+
+async def emit_policy_violation(
+    *,
+    session_id: str,
+    backend_name: str,
+    violation: str,
+    command: str | None = None,
+) -> RuntimeEvent:
+    """Emit a policy-violation event."""
+    return await emit_sandbox_event(
+        "sandbox.policy_violation",
+        session_id=session_id,
+        backend_name=backend_name,
+        command=command,
+        policy_violation=violation,
+    )
+
+
+async def emit_session_destroyed(
+    *,
+    session_id: str,
+    backend_name: str,
+    isolation_level: str = "container",
+) -> RuntimeEvent:
+    """Emit a session-destroyed event."""
+    return await emit_sandbox_event(
+        "sandbox.session_destroyed",
+        session_id=session_id,
+        backend_name=backend_name,
+        isolation_level=isolation_level,
+    )

--- a/agently/builtins/sandbox/gvisor_backend.py
+++ b/agently/builtins/sandbox/gvisor_backend.py
@@ -1,0 +1,338 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+gVisor enhanced sandbox backend.
+
+Extends DockerSandboxBackend by using the gVisor (runsc) OCI runtime for
+system-call interception.  Provides stronger isolation than plain Docker
+while retaining GPU support via nvproxy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from typing import Any
+
+from .docker_backend import DockerSandboxBackend, _ContainerHandle
+from .protocol import IsolationLevel, SandboxConfig, SandboxResult
+
+
+class GVisorSandboxSession:
+    """
+    A gVisor sandbox session — identical to DockerSandboxSession but running
+    inside a container backed by the ``runsc`` runtime.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        container_id: str,
+        docker_binary: str,
+        image: str,
+        config: SandboxConfig,
+    ):
+        self.session_id = session_id
+        self.backend_name = "GVisorSandbox"
+        self.isolation_level = IsolationLevel.ENHANCED_CONTAINER
+        self._container_id = container_id
+        self._docker_binary = docker_binary
+        self._image = image
+        self._config = config
+
+    async def execute(self, command: str, *, timeout: int | None = None) -> SandboxResult:
+        effective_timeout = timeout or self._config.timeout
+        start = time.monotonic()
+
+        escaped = command.replace("\\", "\\\\").replace('"', '\\"')
+        shell_cmd = f'sh -c "{escaped}"'
+
+        result = await asyncio.to_thread(
+            self._run_docker_exec, shell_cmd, effective_timeout,
+        )
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        return SandboxResult(
+            exit_code=result.get("exit_code", 1),
+            stdout=result.get("stdout", ""),
+            stderr=result.get("stderr", ""),
+            execution_time_ms=elapsed_ms,
+            sandbox_id=self._container_id,
+            truncated=result.get("truncated", False),
+        )
+
+    async def execute_python(self, code: str, *, timeout: int | None = None) -> SandboxResult:
+        import shlex as _shlex
+
+        effective_timeout = timeout or self._config.timeout
+        start = time.monotonic()
+
+        wrapped_cmd = f"python -c {_shlex.quote(code)}"
+        result = await asyncio.to_thread(
+            self._run_docker_exec,
+            f'sh -c {_shlex.quote(wrapped_cmd)}',
+            effective_timeout,
+        )
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        return SandboxResult(
+            exit_code=result.get("exit_code", 1),
+            stdout=result.get("stdout", ""),
+            stderr=result.get("stderr", ""),
+            execution_time_ms=elapsed_ms,
+            sandbox_id=self._container_id,
+            truncated=result.get("truncated", False),
+        )
+
+    async def read_file(self, path: str) -> bytes:
+        result = await asyncio.to_thread(
+            self._run_docker_exec, f'cat "{path}"', 10,
+        )
+        if result.get("exit_code", 1) != 0:
+            raise FileNotFoundError(f"Cannot read {path}: {result.get('stderr', '')}")
+        return result.get("stdout", "").encode("utf-8")
+
+    async def write_file(self, path: str, content: bytes) -> None:
+        import base64
+
+        b64 = base64.b64encode(content).decode("ascii")
+        cmd = f'echo {b64} | base64 -d > "{path}"'
+        result = await asyncio.to_thread(self._run_docker_exec, cmd, 10)
+        if result.get("exit_code", 1) != 0:
+            raise OSError(f"Cannot write {path}: {result.get('stderr', '')}")
+
+    async def list_files(self, path: str) -> list[dict[str, Any]]:
+        cmd = f'ls -la "{path}"'
+        result = await asyncio.to_thread(self._run_docker_exec, cmd, 10)
+        entries: list[dict[str, Any]] = []
+        for line in result.get("stdout", "").strip().splitlines():
+            if line.startswith("total "):
+                continue
+            entries.append({"raw": line})
+        return entries
+
+    async def get_status(self) -> dict[str, Any]:
+        result = await asyncio.to_thread(
+            self._run_docker_cmd,
+            ["inspect", "--format", "{{.State.Status}}", self._container_id],
+            5,
+        )
+        return {
+            "session_id": self.session_id,
+            "container_id": self._container_id,
+            "status": result.get("stdout", "unknown").strip(),
+            "backend": self.backend_name,
+            "runtime": "runsc",
+        }
+
+    async def close(self) -> None:
+        await asyncio.to_thread(
+            self._run_docker_cmd, ["stop", "-t", "5", self._container_id], 15,
+        )
+        await asyncio.to_thread(
+            self._run_docker_cmd, ["rm", "-f", self._container_id], 10,
+        )
+
+    # -- internal helpers (same as DockerSandboxSession) --
+
+    def _run_docker_exec(self, cmd: str, timeout: int) -> dict[str, Any]:
+        import subprocess
+
+        args = [self._docker_binary, "exec", self._container_id, "sh", "-c", cmd]
+        try:
+            proc = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+            return {"exit_code": proc.returncode, "stdout": proc.stdout, "stderr": proc.stderr}
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout.decode("utf-8", errors="replace") if isinstance(exc.stdout, bytes) else str(exc.stdout or "")
+            stderr = exc.stderr.decode("utf-8", errors="replace") if isinstance(exc.stderr, bytes) else str(exc.stderr or "")
+            return {"exit_code": -1, "stdout": stdout, "stderr": stderr or "Command timed out", "truncated": True}
+        except Exception as exc:
+            return {"exit_code": 1, "stdout": "", "stderr": str(exc)}
+
+    def _run_docker_cmd(self, sub_args: list[str], timeout: int) -> dict[str, Any]:
+        import subprocess
+
+        args = [self._docker_binary, *sub_args]
+        try:
+            proc = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+            return {"exit_code": proc.returncode, "stdout": proc.stdout, "stderr": proc.stderr}
+        except Exception as exc:
+            return {"exit_code": 1, "stdout": "", "stderr": str(exc)}
+
+
+class GVisorSandboxBackend(DockerSandboxBackend):
+    """
+    gVisor enhanced sandbox backend.
+
+    Inherits container pool management from DockerSandboxBackend but overrides
+    container creation to use the ``runsc`` OCI runtime for system-call
+    interception.
+
+    Key differences from DockerSandboxBackend:
+    - ``--runtime=runsc`` on container creation
+    - ``RUNSC_FLAGS=--platform=systrap`` for syscall interception mode
+    - GPU support via nvproxy (multi-card visible, no MIG slicing)
+    - ~70-80% syscall compatibility vs 100% for plain Docker
+    """
+
+    name = "GVisorSandbox"
+    supported_isolation_levels = [IsolationLevel.ENHANCED_CONTAINER]
+
+    async def create_session(self, config: SandboxConfig) -> GVisorSandboxSession:
+        """Create a gVisor-backed sandbox session."""
+        if self._docker_available is None:
+            self._docker_available = await self._check_docker()
+        if not self._docker_available:
+            raise RuntimeError(
+                f"Docker binary '{self._docker_binary}' is not available. "
+                "Ensure Docker is installed and the daemon is running."
+            )
+
+        session_id = f"gvisor-{uuid.uuid4().hex[:12]}"
+
+        async with self._lock:
+            handle = self._find_idle_container(config.image)
+            if handle is not None:
+                handle.session_id = session_id
+                handle.last_used = time.time()
+                self._active[session_id] = handle
+            else:
+                if len(self._active) + len(self._pool) >= self._pool_max:
+                    await self._shrink_pool()
+                container_id = await self._create_gvisor_container(config, session_id)
+                handle = _ContainerHandle(
+                    container_id=container_id,
+                    image=config.image,
+                    session_id=session_id,
+                )
+                self._active[session_id] = handle
+
+        return GVisorSandboxSession(
+            session_id=session_id,
+            container_id=handle.container_id,
+            docker_binary=self._docker_binary,
+            image=config.image,
+            config=config,
+        )
+
+    async def health_check(self) -> dict[str, Any]:
+        """Check gVisor backend health including runsc runtime availability."""
+        base = await super().health_check()
+        base["backend"] = self.name
+        base["runsc_available"] = await self._check_runsc()
+        base["healthy"] = base["healthy"] and base["runsc_available"]
+        return base
+
+    def capabilities(self) -> dict[str, Any]:
+        caps = super().capabilities()
+        caps.update({
+            "backend": self.name,
+            "isolation_levels": [lvl.value for lvl in self.supported_isolation_levels],
+            "syscall_interception": True,
+            "gpu_support": True,
+            "gpu_mig_support": False,  # gVisor supports multi-card but NOT MIG
+            "kernel_isolation": True,
+        })
+        return caps
+
+    # -- gVisor-specific方法 --
+
+    async def _create_gvisor_container(self, config: SandboxConfig, session_id: str) -> str:
+        """Create a container with gVisor (runsc) runtime."""
+        container_name = f"agently-gvisor-{session_id}"
+
+        args = [
+            self._docker_binary, "run", "-d",
+            "--name", container_name,
+            "--runtime", "runsc",
+            "--label", "agently.sandbox=true",
+            "--label", "agently.sandbox.runtime=runsc",
+            "--label", f"agently.session={session_id}",
+        ]
+
+        # gVisor platform configuration
+        args.extend(["-e", "RUNSC_FLAGS=--platform=systrap"])
+
+        # Resource limits
+        args.extend(["--memory", config.memory_limit])
+        cpu_period = 100000
+        cpu_quota = int(cpu_period * config.cpu_limit)
+        args.extend(["--cpu-period", str(cpu_period), "--cpu-quota", str(cpu_quota)])
+
+        # Security hardening
+        args.extend(["--security-opt", "no-new-privileges:true"])
+        if config.drop_capabilities:
+            args.extend(["--cap-drop", "ALL"])
+        args.extend(["--user", f"{config.run_as_user}:{config.run_as_user}"])
+
+        # Filesystem
+        if config.read_only_fs:
+            args.append("--read-only")
+        args.extend([
+            "--tmpfs", f"/tmp:size={config.writable_tmp_size},noexec,nosuid",
+        ])
+
+        # Network
+        if not config.network_enabled:
+            args.extend(["--network", "none"])
+
+        # GPU support via nvproxy
+        if config.gpu_enabled and config.gpu_device_ids:
+            device_ids = ",".join(str(i) for i in config.gpu_device_ids)
+            args.extend(["--gpus", f'"device={device_ids}"'])
+
+        # Volume mounts
+        for host_path, container_path in config.mount_volumes.items():
+            args.extend(["-v", f"{host_path}:{container_path}"])
+
+        # Image and keep-alive
+        args.append(config.image)
+        args.extend(["sleep", "infinity"])
+
+        result = await asyncio.to_thread(self._subprocess_run, args, 30)
+        if result.get("exit_code", 1) != 0:
+            stderr = result.get("stderr", "")
+            if "runtime" in stderr.lower() or "runsc" in stderr.lower():
+                raise RuntimeError(
+                    f"gVisor runtime 'runsc' is not properly configured. "
+                    f"Install gVisor and register the runsc runtime with Docker. "
+                    f"Original error: {stderr}"
+                )
+            raise RuntimeError(f"Failed to create gVisor sandbox container: {stderr}")
+
+        container_id = result.get("stdout", "").strip()
+        if not container_id:
+            raise RuntimeError("Failed to get container ID after gVisor container creation")
+        return container_id[:12]
+
+    async def _check_runsc(self) -> bool:
+        """Check if gVisor runsc runtime is available."""
+        def _check() -> bool:
+            import subprocess
+
+            try:
+                result = subprocess.run(
+                    [self._docker_binary, "info", "--format", "{{.Runtimes}}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                return "runsc" in result.stdout
+            except Exception:
+                return False
+
+        return await asyncio.to_thread(_check)

--- a/agently/builtins/sandbox/network_policy.py
+++ b/agently/builtins/sandbox/network_policy.py
@@ -1,0 +1,174 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Network egress policy engine for sandbox backends.
+
+Provides fine-grained network access control including cloud metadata API
+blocking, domain allowlisting, and full network isolation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .protocol import SandboxConfig
+
+
+# ---------------------------------------------------------------------------
+# Rule types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class NetworkRule:
+    """A single network policy rule."""
+
+    action: str  # "allow" | "deny"
+    dst: str
+    reason: str
+    port: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"action": self.action, "dst": self.dst, "reason": self.reason}
+        if self.port is not None:
+            d["port"] = self.port
+        return d
+
+
+@dataclass
+class NetworkPolicy:
+    """Evaluated network policy — a list of rules to apply."""
+
+    rules: list[NetworkRule] = field(default_factory=list)
+
+    @property
+    def is_completely_blocked(self) -> bool:
+        """Whether all network access is denied."""
+        return any(r.action == "deny" and r.dst == "*" for r in self.rules)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"rules": [r.to_dict() for r in self.rules]}
+
+
+# ---------------------------------------------------------------------------
+# NetworkPolicyEngine
+# ---------------------------------------------------------------------------
+
+class NetworkPolicyEngine:
+    """
+    Network egress policy engine.
+
+    Evaluates a SandboxConfig and produces a NetworkPolicy with concrete rules
+    for iptables / Docker network configuration.
+
+    Built-in blocked endpoints (cloud metadata APIs):
+    - 169.254.169.254 (AWS / GCP)
+    - 100.100.100.200 (Alibaba Cloud)
+    - metadata.google.internal (GCP)
+    - metadata.azure.com (Azure)
+    """
+
+    BLOCKED_ENDPOINTS: dict[str, str] = {
+        "169.254.169.254": "aws_gcp_metadata",
+        "100.100.100.200": "alicloud_metadata",
+        "metadata.google.internal": "gcp_metadata",
+        "metadata.azure.com": "azure_metadata",
+    }
+
+    async def evaluate(self, config: SandboxConfig) -> NetworkPolicy:
+        """
+        Evaluate network policy from sandbox configuration.
+
+        Three modes:
+        1. network_enabled=False → deny all
+        2. network_enabled=True + network_allowlist → deny all + allow listed
+        3. network_enabled=True + no allowlist → allow all (except metadata)
+        """
+        rules: list[NetworkRule] = []
+
+        # Always block cloud metadata when configured
+        if config.block_cloud_metadata:
+            for endpoint, reason in self.BLOCKED_ENDPOINTS.items():
+                rules.append(NetworkRule(
+                    action="deny",
+                    dst=endpoint,
+                    reason=reason,
+                ))
+
+        # Mode 1: Network completely disabled
+        if not config.network_enabled:
+            rules.append(NetworkRule(
+                action="deny",
+                dst="*",
+                reason="network_disabled",
+            ))
+            return NetworkPolicy(rules=rules)
+
+        # Mode 2: Allowlist mode
+        if config.network_allowlist:
+            # Deny all first, then allow specific destinations
+            rules.append(NetworkRule(
+                action="deny",
+                dst="*",
+                reason="allowlist_mode",
+            ))
+            for allowed in config.network_allowlist:
+                rules.append(NetworkRule(
+                    action="allow",
+                    dst=allowed,
+                    reason="allowlisted",
+                ))
+            return NetworkPolicy(rules=rules)
+
+        # Mode 3: Network enabled, no allowlist — only metadata blocked
+        return NetworkPolicy(rules=rules)
+
+    async def apply_to_docker_args(
+        self,
+        docker_args: list[str],
+        policy: NetworkPolicy,
+    ) -> list[str]:
+        """
+        Apply network policy to Docker container creation arguments.
+
+        Modifies the argument list to enforce network restrictions.
+        """
+        if policy.is_completely_blocked:
+            # Remove any existing --network arg and set to none
+            filtered = self._remove_network_args(docker_args)
+            filtered.extend(["--network", "none"])
+            return filtered
+
+        # For allowlist or partial policies, use a custom network
+        # (Full iptables management is out of scope for this implementation;
+        #  the Docker --network=none provides the strongest isolation.)
+        return docker_args
+
+    @staticmethod
+    def _remove_network_args(args: list[str]) -> list[str]:
+        """Remove --network related arguments from a Docker args list."""
+        result: list[str] = []
+        skip_next = False
+        for i, arg in enumerate(args):
+            if skip_next:
+                skip_next = False
+                continue
+            if arg == "--network":
+                skip_next = True
+                continue
+            if arg.startswith("--network="):
+                continue
+            result.append(arg)
+        return result

--- a/agently/builtins/sandbox/protocol.py
+++ b/agently/builtins/sandbox/protocol.py
@@ -1,0 +1,147 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Sandbox backend protocol definitions.
+
+Defines the abstract interface for pluggable sandbox backends (Docker, gVisor,
+containerd, etc.) that provide real isolation for Agent code execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class IsolationLevel(str, Enum):
+    """Isolation level — maps to sandbox technology tiers."""
+
+    PROCESS = "process"  # Process-level (restricted exec, legacy level)
+    CONTAINER = "container"  # Container-level (Docker namespace+cgroup)
+    ENHANCED_CONTAINER = "enhanced"  # Enhanced container (gVisor syscall interception)
+    MICROVM = "microvm"  # Micro-VM (Firecracker independent kernel)
+
+
+@dataclass
+class SandboxConfig:
+    """Sandbox session configuration covering five security dimensions."""
+
+    image: str = "python:3.12-slim"
+    isolation_level: IsolationLevel = IsolationLevel.CONTAINER
+
+    # Resource limits
+    memory_limit: str = "512m"
+    cpu_limit: float = 1.0
+    disk_limit: str = "1g"
+    timeout: int = 30
+
+    # Network policy
+    network_enabled: bool = False
+    network_allowlist: list[str] = field(default_factory=list)
+    block_cloud_metadata: bool = True
+
+    # Filesystem
+    read_only_fs: bool = True
+    writable_tmp_size: str = "100m"
+    mount_volumes: dict[str, str] = field(default_factory=dict)
+
+    # Permissions
+    drop_capabilities: bool = True
+    no_new_privileges: bool = True
+    run_as_user: int = 1000
+
+    # GPU (gVisor scenario)
+    gpu_enabled: bool = False
+    gpu_device_ids: list[int] = field(default_factory=list)
+
+    # Container pool
+    pool_min: int = 1
+    pool_max: int = 10
+    idle_timeout: int = 300
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "image": self.image,
+            "isolation_level": self.isolation_level.value,
+            "memory_limit": self.memory_limit,
+            "cpu_limit": self.cpu_limit,
+            "timeout": self.timeout,
+            "network_enabled": self.network_enabled,
+            "read_only_fs": self.read_only_fs,
+            "gpu_enabled": self.gpu_enabled,
+        }
+
+
+@dataclass
+class SandboxResult:
+    """Sandbox execution result."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    execution_time_ms: float
+    sandbox_id: str
+    truncated: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def success(self) -> bool:
+        """Whether the execution succeeded."""
+        return self.exit_code == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "exit_code": self.exit_code,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "execution_time_ms": self.execution_time_ms,
+            "sandbox_id": self.sandbox_id,
+            "truncated": self.truncated,
+            "metadata": self.metadata,
+        }
+
+
+@runtime_checkable
+class SandboxSession(Protocol):
+    """Sandbox session — lifecycle of one isolated execution environment."""
+
+    session_id: str
+    backend_name: str
+    isolation_level: IsolationLevel
+
+    async def execute(self, command: str, *, timeout: int | None = None) -> SandboxResult: ...
+    async def execute_python(self, code: str, *, timeout: int | None = None) -> SandboxResult: ...
+    async def read_file(self, path: str) -> bytes: ...
+    async def write_file(self, path: str, content: bytes) -> None: ...
+    async def list_files(self, path: str) -> list[dict[str, Any]]: ...
+    async def get_status(self) -> dict[str, Any]: ...
+    async def close(self) -> None: ...
+
+
+@runtime_checkable
+class SandboxBackend(Protocol):
+    """Sandbox backend — manages creation and destruction of sandbox sessions."""
+
+    name: str
+    supported_isolation_levels: list[IsolationLevel]
+
+    async def create_session(self, config: SandboxConfig) -> SandboxSession: ...
+    async def destroy_session(self, session_id: str) -> None: ...
+    async def list_sessions(self) -> list[str]: ...
+    async def health_check(self) -> dict[str, Any]: ...
+    def capabilities(self) -> dict[str, Any]: ...

--- a/docs/cn/actions/README.md
+++ b/docs/cn/actions/README.md
@@ -7,5 +7,6 @@
 3. [ExecutionResource](execution-environment.md)：面向 Action、TriggerFlow 与插件开发者的高级托管 MCP/sandbox/process/browser/SQLite 资源。
 4. [工具兼容](tools.md)：旧 `tool_func` / `use_tools` 别名的现状。
 5. [MCP](mcp.md)：把 MCP server 挂成 action。
+6. [Sandbox Plugin](../sandbox/README.md)：容器级沙箱执行环境（Docker / gVisor）。
 
 模型请求需要调用模型外部能力时读这个文件夹。主要问题是多步骤编排时读 [TriggerFlow](../triggerflow/)。如果你在判断一个变更应该属于 core、plugin、built-in action 还是 Agent Component，请读 [Architecture / 扩展边界](../architecture/extension-boundaries.md)。

--- a/docs/cn/sandbox/README.md
+++ b/docs/cn/sandbox/README.md
@@ -1,0 +1,255 @@
+---
+title: Sandbox Plugin
+description: Agently 沙箱插件系统 — 容器级隔离执行环境。
+keywords: Agently, sandbox, Docker, gVisor, container, isolation, security
+---
+
+# Sandbox Plugin
+
+> 语言：[English](../../en/sandbox/README.md) · **中文**
+
+Sandbox Plugin 是 Agently 的容器级沙箱执行环境，为 Agent 动作提供安全隔离的运行时。
+
+## 概述
+
+沙箱插件系统提供两种隔离级别：
+
+| 隔离级别 | 后端 | 隔离机制 | 适用场景 |
+|----------|------|----------|----------|
+| `CONTAINER` | `DockerSandboxBackend` | Linux namespace + cgroup | 一般沙箱任务 |
+| `ENHANCED_CONTAINER` | `GVisorSandboxBackend` | 用户态内核 syscall 拦截 | 高安全要求场景 |
+
+## 模块结构
+
+```text
+agently/builtins/sandbox/
+├── protocol.py          # 核心协议类型定义
+├── docker_backend.py    # Docker 运行时后端
+├── gvisor_backend.py    # gVisor 运行时后端
+├── network_policy.py    # 网络策略引擎
+└── events.py            # 事件发射器
+```
+
+## 核心协议
+
+### IsolationLevel
+
+```python
+from agently.builtins.sandbox.protocol import IsolationLevel
+
+IsolationLevel.CONTAINER           # 标准容器隔离
+IsolationLevel.ENHANCED_CONTAINER  # gVisor 增强隔离
+```
+
+### SandboxConfig
+
+```python
+from agently.builtins.sandbox.protocol import SandboxConfig
+
+config = SandboxConfig(
+    # 容器配置
+    image="python:3.12-slim",
+    isolation_level=IsolationLevel.CONTAINER,
+    
+    # 资源限制
+    memory_limit="512m",
+    cpu_limit=1.0,
+    timeout=30,
+    
+    # 网络策略
+    network_enabled=False,
+    network_allowlist=[],
+    block_cloud_metadata=True,
+    
+    # 文件系统
+    read_only_fs=True,
+    writable_tmp_size="100m",
+    
+    # 权限
+    drop_capabilities=True,
+    no_new_privileges=True,
+)
+```
+
+### SandboxResult
+
+```python
+from agently.builtins.sandbox.protocol import SandboxResult
+
+result: SandboxResult = await session.execute("echo hello")
+print(result.exit_code)   # 0
+print(result.stdout)      # "hello\n"
+print(result.success)     # True
+```
+
+## 后端使用
+
+### DockerSandboxBackend
+
+```python
+import asyncio
+from agently.builtins.sandbox.docker_backend import DockerSandboxBackend
+from agently.builtins.sandbox.protocol import SandboxConfig
+
+async def main():
+    backend = DockerSandboxBackend()
+    config = SandboxConfig(timeout=30)
+    
+    # 创建会话
+    session = await backend.create_session(config)
+    print(f"Session: {session.session_id}")
+    
+    # 执行命令
+    result = await session.execute("echo hello")
+    print(result.stdout)
+    
+    # 执行 Python 代码
+    result = await session.execute_python("print(2 + 2)")
+    
+    # 关闭
+    await session.close()
+    await backend.destroy_session(session.session_id)
+
+asyncio.run(main())
+```
+
+### GVisorSandboxBackend
+
+```python
+import asyncio
+from agently.builtins.sandbox.gvisor_backend import GVisorSandboxBackend
+from agently.builtins.sandbox.protocol import SandboxConfig
+
+async def main():
+    backend = GVisorSandboxBackend()
+    config = SandboxConfig(timeout=30)
+    
+    # 创建 gVisor 会话（使用 runsc 运行时）
+    session = await backend.create_session(config)
+    print(f"Isolation: {session.isolation_level}")  # ENHANCED_CONTAINER
+    
+    # 执行命令（在 gVisor 沙箱中）
+    result = await session.execute("echo hello from gVisor")
+    
+    # 关闭
+    await session.close()
+    await backend.destroy_session(session.session_id)
+
+asyncio.run(main())
+```
+
+## 网络策略
+
+```python
+from agently.builtins.sandbox.network_policy import NetworkPolicyEngine
+from agently.builtins.sandbox.protocol import SandboxConfig
+
+engine = NetworkPolicyEngine()
+
+# 网络禁用配置
+config = SandboxConfig(network_enabled=False)
+policy = engine.evaluate(config)
+print(policy.allowed)  # False
+
+# 网络白名单配置
+config = SandboxConfig(
+    network_enabled=True,
+    network_allowlist=["pypi.org", "github.com"],
+)
+policy = engine.evaluate(config)
+print(policy.allowed_domains)  # ["pypi.org", "github.com"]
+```
+
+## SandboxActionExecutor
+
+统一沙箱执行器，符合 Agently Action Executor 协议：
+
+```python
+from agently.builtins.plugins.ActionExecutor.SandboxActionExecutor import SandboxActionExecutor
+
+executor = SandboxActionExecutor(
+    backend="docker",           # "docker" 或 "gvisor"
+    default_image="python:3.12-slim",
+    network_enabled=False,
+)
+
+# 协议属性
+print(f"kind: {executor.kind}")          # "sandbox"
+print(f"sandboxed: {executor.sandboxed}")  # True
+
+# 执行动作
+result = await executor.execute(
+    spec={"action_id": "sandbox"},
+    action_call={"action_input": {"cmd": "echo hello"}},
+    policy={"timeout_seconds": 60},
+    settings=None,
+)
+```
+
+## 事件系统
+
+```python
+from agently.builtins.sandbox.events import (
+    emit_session_created,
+    emit_execution_completed,
+    emit_policy_violation,
+)
+
+# 监听事件
+# 事件通过 Agently 事件总线发射，可在 Agent 层订阅
+```
+
+## 环境要求
+
+### Docker 模式
+- Docker >= 20.x
+- 无需额外配置
+
+### gVisor 模式
+- Docker >= 20.x
+- gVisor (runsc) 已安装并注册到 Docker
+
+安装 gVisor：
+
+```bash
+# 下载 runsc
+wget -O runsc https://storage.googleapis.com/gvisor/releases/release/latest/x86_64/runsc
+sudo install -m 0755 runsc /usr/local/bin/runsc
+
+# 配置 Docker daemon
+sudo tee /etc/docker/daemon.json > /dev/null << 'EOF'
+{
+  "runtimes": {
+    "runsc": {
+      "path": "/usr/local/bin/runsc",
+      "runtimeArgs": []
+    }
+  }
+}
+EOF
+
+# 重启 Docker
+sudo systemctl restart docker
+
+# 验证
+runsc --version
+docker run --runtime=runsc --rm hello-world
+```
+
+## 判断运行时
+
+```bash
+# 查看容器运行时
+docker inspect <container_id> --format '{{.HostConfig.Runtime}}'
+# runc = Docker 模式, runsc = gVisor 模式
+
+# 查看内核
+docker exec <container_id> uname -r
+# 宿主机内核 = Docker, 4.19.0-gvisor = gVisor
+```
+
+## 相关文档
+
+- [Actions](../actions/README.md) — Action 执行架构
+- [Execution Resource](../actions/execution-environment.md) — 托管执行资源层
+- [Architecture](../architecture/README.md) — 系统架构概览

--- a/docs/en/actions/README.md
+++ b/docs/en/actions/README.md
@@ -7,5 +7,6 @@ Read in this order:
 3. [ExecutionResource](execution-environment.md): advanced managed MCP/sandbox/process/browser/SQLite resources for Action, TriggerFlow, and plugin authors.
 4. [Tools Compatibility](tools.md): old `tool_func` / `use_tools` aliases and their current status.
 5. [MCP](mcp.md): mounting MCP servers as actions.
+6. [Sandbox Plugin](../sandbox/README.md): container-level isolated execution environment (Docker / gVisor).
 
 Use this folder when a model request needs to call something outside the model. Use [TriggerFlow](../triggerflow/) when the main problem is multi-step orchestration. If you are deciding whether a change belongs to core, a plugin, a built-in action, or an Agent Component, read [Architecture / Extension Boundaries](../architecture/extension-boundaries.md).

--- a/docs/en/sandbox/README.md
+++ b/docs/en/sandbox/README.md
@@ -1,0 +1,254 @@
+---
+title: Sandbox Plugin
+description: Agently Sandbox Plugin System — Container-level Isolated Execution Environment.
+keywords: Agently, sandbox, Docker, gVisor, container, isolation, security
+---
+
+# Sandbox Plugin
+
+> Language: **English** · [中文](../../cn/sandbox/README.md)
+
+The Sandbox Plugin provides container-level isolated execution environments for Agent actions.
+
+## Overview
+
+The sandbox plugin system offers two isolation levels:
+
+| Isolation Level | Backend | Isolation Mechanism | Use Case |
+|-----------------|---------|---------------------|----------|
+| `CONTAINER` | `DockerSandboxBackend` | Linux namespace + cgroup | General sandbox tasks |
+| `ENHANCED_CONTAINER` | `GVisorSandboxBackend` | User-space kernel syscall interception | High-security scenarios |
+
+## Module Structure
+
+```text
+agently/builtins/sandbox/
+├── protocol.py          # Core protocol type definitions
+├── docker_backend.py    # Docker runtime backend
+├── gvisor_backend.py    # gVisor runtime backend
+├── network_policy.py    # Network policy engine
+└── events.py            # Event emitter
+```
+
+## Core Protocol
+
+### IsolationLevel
+
+```python
+from agently.builtins.sandbox.protocol import IsolationLevel
+
+IsolationLevel.CONTAINER           # Standard container isolation
+IsolationLevel.ENHANCED_CONTAINER  # gVisor enhanced isolation
+```
+
+### SandboxConfig
+
+```python
+from agently.builtins.sandbox.protocol import SandboxConfig
+
+config = SandboxConfig(
+    # Container configuration
+    image="python:3.12-slim",
+    isolation_level=IsolationLevel.CONTAINER,
+    
+    # Resource limits
+    memory_limit="512m",
+    cpu_limit=1.0,
+    timeout=30,
+    
+    # Network policy
+    network_enabled=False,
+    network_allowlist=[],
+    block_cloud_metadata=True,
+    
+    # Filesystem
+    read_only_fs=True,
+    writable_tmp_size="100m",
+    
+    # Permissions
+    drop_capabilities=True,
+    no_new_privileges=True,
+)
+```
+
+### SandboxResult
+
+```python
+from agently.builtins.sandbox.protocol import SandboxResult
+
+result: SandboxResult = await session.execute("echo hello")
+print(result.exit_code)   # 0
+print(result.stdout)      # "hello\n"
+print(result.success)     # True
+```
+
+## Backend Usage
+
+### DockerSandboxBackend
+
+```python
+import asyncio
+from agently.builtins.sandbox.docker_backend import DockerSandboxBackend
+from agently.builtins.sandbox.protocol import SandboxConfig
+
+async def main():
+    backend = DockerSandboxBackend()
+    config = SandboxConfig(timeout=30)
+    
+    # Create session
+    session = await backend.create_session(config)
+    print(f"Session: {session.session_id}")
+    
+    # Execute command
+    result = await session.execute("echo hello")
+    print(result.stdout)
+    
+    # Execute Python code
+    result = await session.execute_python("print(2 + 2)")
+    
+    # Cleanup
+    await session.close()
+    await backend.destroy_session(session.session_id)
+
+asyncio.run(main())
+```
+
+### GVisorSandboxBackend
+
+```python
+import asyncio
+from agently.builtins.sandbox.gvisor_backend import GVisorSandboxBackend
+from agently.builtins.sandbox.protocol import SandboxConfig
+
+async def main():
+    backend = GVisorSandboxBackend()
+    config = SandboxConfig(timeout=30)
+    
+    # Create gVisor session (uses runsc runtime)
+    session = await backend.create_session(config)
+    print(f"Isolation: {session.isolation_level}")  # ENHANCED_CONTAINER
+    
+    # Execute command (inside gVisor sandbox)
+    result = await session.execute("echo hello from gVisor")
+    
+    # Cleanup
+    await session.close()
+    await backend.destroy_session(session.session_id)
+
+asyncio.run(main())
+```
+
+## Network Policy
+
+```python
+from agently.builtins.sandbox.network_policy import NetworkPolicyEngine
+from agently.builtins.sandbox.protocol import SandboxConfig
+
+engine = NetworkPolicyEngine()
+
+# Network disabled configuration
+config = SandboxConfig(network_enabled=False)
+policy = engine.evaluate(config)
+print(policy.allowed)  # False
+
+# Network allowlist configuration
+config = SandboxConfig(
+    network_enabled=True,
+    network_allowlist=["pypi.org", "github.com"],
+)
+policy = engine.evaluate(config)
+print(policy.allowed_domains)  # ["pypi.org", "github.com"]
+```
+
+## SandboxActionExecutor
+
+Unified sandbox executor compliant with Agently Action Executor protocol:
+
+```python
+from agently.builtins.plugins.ActionExecutor.SandboxActionExecutor import SandboxActionExecutor
+
+executor = SandboxActionExecutor(
+    backend="docker",           # "docker" or "gvisor"
+    default_image="python:3.12-slim",
+    network_enabled=False,
+)
+
+# Protocol attributes
+print(f"kind: {executor.kind}")          # "sandbox"
+print(f"sandboxed: {executor.sandboxed}")  # True
+
+# Execute action
+result = await executor.execute(
+    spec={"action_id": "sandbox"},
+    action_call={"action_input": {"cmd": "echo hello"}},
+    policy={"timeout_seconds": 60},
+    settings=None,
+)
+```
+
+## Event System
+
+```python
+from agently.builtins.sandbox.events import (
+    emit_session_created,
+    emit_execution_completed,
+    emit_policy_violation,
+)
+
+# Events are emitted via Agently event bus, subscribable at Agent layer
+```
+
+## Environment Requirements
+
+### Docker Mode
+- Docker >= 20.x
+- No additional configuration required
+
+### gVisor Mode
+- Docker >= 20.x
+- gVisor (runsc) installed and registered with Docker
+
+Installing gVisor:
+
+```bash
+# Download runsc
+wget -O runsc https://storage.googleapis.com/gvisor/releases/release/latest/x86_64/runsc
+sudo install -m 0755 runsc /usr/local/bin/runsc
+
+# Configure Docker daemon
+sudo tee /etc/docker/daemon.json > /dev/null << 'EOF'
+{
+  "runtimes": {
+    "runsc": {
+      "path": "/usr/local/bin/runsc",
+      "runtimeArgs": []
+    }
+  }
+}
+EOF
+
+# Restart Docker
+sudo systemctl restart docker
+
+# Verify
+runsc --version
+docker run --runtime=runsc --rm hello-world
+```
+
+## Identifying Runtime
+
+```bash
+# Check container runtime
+docker inspect <container_id> --format '{{.HostConfig.Runtime}}'
+# runc = Docker mode, runsc = gVisor mode
+
+# Check kernel
+docker exec <container_id> uname -r
+# Host kernel = Docker, 4.19.0-gvisor = gVisor
+```
+
+## Related Documentation
+
+- [Actions](../actions/README.md) — Action execution architecture
+- [Execution Resource](../actions/execution-environment.md) — Managed execution resource layer
+- [Architecture](../architecture/README.md) — System architecture overview

--- a/tests/test_sandbox/__init__.py
+++ b/tests/test_sandbox/__init__.py
@@ -1,0 +1,1 @@
+# Tests for sandbox plugin

--- a/tests/test_sandbox/test_docker_backend.py
+++ b/tests/test_sandbox/test_docker_backend.py
@@ -1,0 +1,262 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for Docker sandbox backend with mocked Docker CLI."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agently.builtins.sandbox.docker_backend import (
+    DockerSandboxBackend,
+    DockerSandboxSession,
+    _ContainerHandle,
+)
+from agently.builtins.sandbox.protocol import IsolationLevel, SandboxConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(**overrides) -> SandboxConfig:
+    defaults = dict(
+        image="python:3.12-slim",
+        timeout=30,
+        memory_limit="512m",
+        cpu_limit=1.0,
+    )
+    defaults.update(overrides)
+    return SandboxConfig(**defaults)
+
+
+def _mock_subprocess_ok(stdout="abc123def456"):
+    """Return a mock that simulates a successful subprocess.run."""
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.stdout = stdout
+    mock_proc.stderr = ""
+    return mock_proc
+
+
+# ---------------------------------------------------------------------------
+# _ContainerHandle
+# ---------------------------------------------------------------------------
+
+class TestContainerHandle:
+    def test_defaults(self):
+        h = _ContainerHandle(container_id="abc", image="python:3.12-slim", session_id="s1")
+        assert h.container_id == "abc"
+        assert h.is_healthy is True
+        assert h.session_id == "s1"
+
+
+# ---------------------------------------------------------------------------
+# DockerSandboxSession
+# ---------------------------------------------------------------------------
+
+class TestDockerSandboxSession:
+    @pytest.fixture
+    def session(self):
+        return DockerSandboxSession(
+            session_id="test-session",
+            container_id="ctr-123",
+            docker_binary="docker",
+            image="python:3.12-slim",
+            config=_make_config(),
+        )
+
+    def test_session_attributes(self, session):
+        assert session.session_id == "test-session"
+        assert session.backend_name == "DockerSandbox"
+        assert session.isolation_level == IsolationLevel.CONTAINER
+
+    def test_execute_success(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="hello world\n")
+        with patch("subprocess.run", return_value=mock_proc):
+            result = asyncio.run(session.execute("echo hello"))
+        assert result.exit_code == 0
+        assert "hello world" in result.stdout
+        assert result.sandbox_id == "ctr-123"
+
+    def test_execute_failure(self, session):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.stdout = ""
+        mock_proc.stderr = "command not found"
+        with patch("subprocess.run", return_value=mock_proc):
+            result = asyncio.run(session.execute("bad_cmd"))
+        assert result.exit_code == 1
+        assert "command not found" in result.stderr
+
+    def test_execute_timeout(self, session):
+        import subprocess
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=1)):
+            result = asyncio.run(session.execute("sleep 999", timeout=1))
+        assert result.exit_code == -1
+        assert result.truncated is True
+
+    def test_execute_python(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="42\n")
+        with patch("subprocess.run", return_value=mock_proc):
+            result = asyncio.run(session.execute_python("print(42)"))
+        assert result.exit_code == 0
+        assert "42" in result.stdout
+
+    def test_read_file(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="file content")
+        with patch("subprocess.run", return_value=mock_proc):
+            data = asyncio.run(session.read_file("/tmp/test.txt"))
+        assert data == b"file content"
+
+    def test_read_file_not_found(self, session):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.stdout = ""
+        mock_proc.stderr = "No such file"
+        with patch("subprocess.run", return_value=mock_proc):
+            with pytest.raises(FileNotFoundError):
+                asyncio.run(session.read_file("/nonexistent"))
+
+    def test_write_file(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="")
+        with patch("subprocess.run", return_value=mock_proc):
+            asyncio.run(session.write_file("/tmp/out.txt", b"data"))
+
+    def test_write_file_error(self, session):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.stdout = ""
+        mock_proc.stderr = "Permission denied"
+        with patch("subprocess.run", return_value=mock_proc):
+            with pytest.raises(OSError):
+                asyncio.run(session.write_file("/readonly", b"data"))
+
+    def test_list_files(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="total 8\n-rw-r--r-- 1 root root 100 Jan 1 file.txt\n")
+        with patch("subprocess.run", return_value=mock_proc):
+            entries = asyncio.run(session.list_files("/tmp"))
+        assert len(entries) >= 1
+
+    def test_get_status(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="running\n")
+        with patch("subprocess.run", return_value=mock_proc):
+            status = asyncio.run(session.get_status())
+        assert status["session_id"] == "test-session"
+        assert status["backend"] == "DockerSandbox"
+        assert "running" in status["status"]
+
+    def test_close(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="")
+        with patch("subprocess.run", return_value=mock_proc):
+            asyncio.run(session.close())
+
+
+# ---------------------------------------------------------------------------
+# DockerSandboxBackend
+# ---------------------------------------------------------------------------
+
+class TestDockerSandboxBackend:
+    def test_name(self):
+        backend = DockerSandboxBackend()
+        assert backend.name == "DockerSandbox"
+
+    def test_supported_isolation_levels(self):
+        backend = DockerSandboxBackend()
+        assert IsolationLevel.CONTAINER in backend.supported_isolation_levels
+
+    def test_capabilities(self):
+        backend = DockerSandboxBackend()
+        caps = backend.capabilities()
+        assert caps["backend"] == "DockerSandbox"
+        assert caps["read_only_fs"] is True
+        assert caps["gpu_support"] is False
+        assert caps["resource_limits"] is True
+
+    def test_health_check_no_docker(self):
+        backend = DockerSandboxBackend(docker_binary="nonexistent_docker_bin")
+        result = asyncio.run(backend.health_check())
+        assert result["healthy"] is False
+        assert result["docker_available"] is False
+
+    def test_list_sessions_empty(self):
+        backend = DockerSandboxBackend()
+        result = asyncio.run(backend.list_sessions())
+        assert result == []
+
+    def test_create_session_docker_not_available(self):
+        backend = DockerSandboxBackend(docker_binary="nonexistent_docker_bin")
+        with pytest.raises(RuntimeError, match="not available"):
+            asyncio.run(backend.create_session(_make_config()))
+
+    def test_create_session_success(self):
+        backend = DockerSandboxBackend()
+        mock_proc = _mock_subprocess_ok(stdout="abc123def45678901234567890123456")
+        with patch("subprocess.run", return_value=mock_proc):
+            with patch("shutil.which", return_value="/usr/bin/docker"):
+                session = asyncio.run(backend.create_session(_make_config()))
+        assert isinstance(session, DockerSandboxSession)
+        assert session.session_id.startswith("sandbox-")
+
+    def test_destroy_session_returns_to_pool(self):
+        backend = DockerSandboxBackend(pool_min=1, pool_max=5)
+        mock_proc = _mock_subprocess_ok(stdout="abc123def45678901234567890123456")
+        with patch("subprocess.run", return_value=mock_proc):
+            with patch("shutil.which", return_value="/usr/bin/docker"):
+                session = asyncio.run(backend.create_session(_make_config()))
+                sid = session.session_id
+                assert len(asyncio.run(backend.list_sessions())) == 1
+                asyncio.run(backend.destroy_session(sid))
+                assert len(asyncio.run(backend.list_sessions())) == 0
+                assert len(backend._pool) == 1
+
+    def test_destroy_session_unknown_id(self):
+        backend = DockerSandboxBackend()
+        asyncio.run(backend.destroy_session("nonexistent-session"))
+
+    def test_pool_reuse(self):
+        backend = DockerSandboxBackend(pool_min=1, pool_max=5)
+        mock_proc = _mock_subprocess_ok(stdout="abc123def45678901234567890123456")
+        with patch("subprocess.run", return_value=mock_proc):
+            with patch("shutil.which", return_value="/usr/bin/docker"):
+                s1 = asyncio.run(backend.create_session(_make_config()))
+                sid1 = s1.session_id
+                asyncio.run(backend.destroy_session(sid1))
+                assert len(backend._pool) == 1
+                s2 = asyncio.run(backend.create_session(_make_config()))
+                assert len(backend._pool) == 0
+                assert s2.session_id != sid1
+
+    def test_security_args_in_create(self):
+        """Verify that container creation includes security hardening args."""
+        backend = DockerSandboxBackend()
+        captured_args = []
+
+        def capture_subprocess(args, **kwargs):
+            captured_args.append(args)
+            mock_proc = MagicMock()
+            mock_proc.returncode = 0
+            mock_proc.stdout = "abc123def45678901234567890"
+            mock_proc.stderr = ""
+            return mock_proc
+
+        with patch("subprocess.run", side_effect=capture_subprocess):
+            with patch("shutil.which", return_value="/usr/bin/docker"):
+                asyncio.run(backend.create_session(_make_config()))
+
+        create_call = captured_args[1]
+        assert "--cap-drop" in create_call
+        assert "ALL" in create_call
+        assert "--read-only" in create_call
+        assert "--network" in create_call
+        assert "none" in create_call
+        assert "--security-opt" in create_call
+        assert "no-new-privileges:true" in create_call
+        assert "--label" in create_call
+        assert "agently.sandbox=true" in create_call

--- a/tests/test_sandbox/test_gvisor_backend.py
+++ b/tests/test_sandbox/test_gvisor_backend.py
@@ -1,0 +1,220 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for gVisor sandbox backend with mocked Docker CLI."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agently.builtins.sandbox.gvisor_backend import (
+    GVisorSandboxBackend,
+    GVisorSandboxSession,
+)
+from agently.builtins.sandbox.protocol import IsolationLevel, SandboxConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(**overrides) -> SandboxConfig:
+    defaults = dict(
+        image="python:3.12-slim",
+        timeout=30,
+        memory_limit="512m",
+        cpu_limit=1.0,
+    )
+    defaults.update(overrides)
+    return SandboxConfig(**defaults)
+
+
+def _mock_subprocess_ok(stdout="abc123def456"):
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.stdout = stdout
+    mock_proc.stderr = ""
+    return mock_proc
+
+
+# ---------------------------------------------------------------------------
+# GVisorSandboxSession
+# ---------------------------------------------------------------------------
+
+class TestGVisorSandboxSession:
+    @pytest.fixture
+    def session(self):
+        return GVisorSandboxSession(
+            session_id="gvisor-session",
+            container_id="ctr-gv-123",
+            docker_binary="docker",
+            image="python:3.12-slim",
+            config=_make_config(),
+        )
+
+    def test_session_attributes(self, session):
+        assert session.session_id == "gvisor-session"
+        assert session.backend_name == "GVisorSandbox"
+        assert session.isolation_level == IsolationLevel.ENHANCED_CONTAINER
+
+    def test_execute_success(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="hello from gvisor\n")
+        with patch("subprocess.run", return_value=mock_proc):
+            result = asyncio.run(session.execute("echo hello"))
+        assert result.exit_code == 0
+        assert "hello from gvisor" in result.stdout
+        assert result.sandbox_id == "ctr-gv-123"
+
+    def test_execute_python(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="99\n")
+        with patch("subprocess.run", return_value=mock_proc):
+            result = asyncio.run(session.execute_python("print(99)"))
+        assert result.exit_code == 0
+        assert "99" in result.stdout
+
+    def test_read_file(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="gvisor data")
+        with patch("subprocess.run", return_value=mock_proc):
+            data = asyncio.run(session.read_file("/tmp/test.txt"))
+        assert data == b"gvisor data"
+
+    def test_write_file(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="")
+        with patch("subprocess.run", return_value=mock_proc):
+            asyncio.run(session.write_file("/tmp/out.txt", b"gv_data"))
+
+    def test_get_status_includes_runtime(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="running\n")
+        with patch("subprocess.run", return_value=mock_proc):
+            status = asyncio.run(session.get_status())
+        assert status["backend"] == "GVisorSandbox"
+        assert status["runtime"] == "runsc"
+
+    def test_close(self, session):
+        mock_proc = _mock_subprocess_ok(stdout="")
+        with patch("subprocess.run", return_value=mock_proc):
+            asyncio.run(session.close())
+
+
+# ---------------------------------------------------------------------------
+# GVisorSandboxBackend
+# ---------------------------------------------------------------------------
+
+class TestGVisorSandboxBackend:
+    def test_name(self):
+        backend = GVisorSandboxBackend()
+        assert backend.name == "GVisorSandbox"
+
+    def test_supported_isolation_levels(self):
+        backend = GVisorSandboxBackend()
+        assert IsolationLevel.ENHANCED_CONTAINER in backend.supported_isolation_levels
+
+    def test_capabilities(self):
+        backend = GVisorSandboxBackend()
+        caps = backend.capabilities()
+        assert caps["backend"] == "GVisorSandbox"
+        assert caps["syscall_interception"] is True
+        assert caps["gpu_support"] is True
+        assert caps["gpu_mig_support"] is False
+        assert caps["kernel_isolation"] is True
+
+    def test_health_check_no_docker(self):
+        backend = GVisorSandboxBackend(docker_binary="nonexistent_docker_bin")
+        result = asyncio.run(backend.health_check())
+        assert result["healthy"] is False
+        assert result["backend"] == "GVisorSandbox"
+
+    def test_health_check_no_runsc(self):
+        """When docker is available but runsc is not, health should be False."""
+        backend = GVisorSandboxBackend()
+        call_count = [0]
+
+        def mock_subprocess(args, **kwargs):
+            call_count[0] += 1
+            mock_proc = MagicMock()
+            mock_proc.returncode = 0
+            # docker version check succeeds
+            if "version" in args:
+                mock_proc.stdout = "24.0.0"
+            # docker info shows no runsc runtime
+            elif "info" in args:
+                mock_proc.stdout = "map[runc:]"
+            else:
+                mock_proc.stdout = ""
+            mock_proc.stderr = ""
+            return mock_proc
+
+        with patch("subprocess.run", side_effect=mock_subprocess):
+            with patch("shutil.which", return_value="/usr/bin/docker"):
+                result = asyncio.run(backend.health_check())
+        assert result["runsc_available"] is False
+        assert result["healthy"] is False
+
+    def test_create_session_docker_not_available(self):
+        backend = GVisorSandboxBackend(docker_binary="nonexistent_docker_bin")
+        with pytest.raises(RuntimeError, match="not available"):
+            asyncio.run(backend.create_session(_make_config()))
+
+    def test_create_session_success(self):
+        backend = GVisorSandboxBackend()
+        mock_proc = _mock_subprocess_ok(stdout="gv123def45678901234567890123456")
+        with patch("subprocess.run", return_value=mock_proc):
+            with patch("shutil.which", return_value="/usr/bin/docker"):
+                session = asyncio.run(backend.create_session(_make_config()))
+        assert isinstance(session, GVisorSandboxSession)
+        assert session.session_id.startswith("gvisor-")
+
+    def test_gvisor_runtime_arg_in_create(self):
+        """Verify that container creation includes --runtime runsc."""
+        backend = GVisorSandboxBackend()
+        captured_args = []
+
+        def capture_subprocess(args, **kwargs):
+            captured_args.append(args)
+            mock_proc = MagicMock()
+            mock_proc.returncode = 0
+            mock_proc.stdout = "gv123def45678901234567890123456"
+            mock_proc.stderr = ""
+            return mock_proc
+
+        with patch("subprocess.run", side_effect=capture_subprocess):
+            with patch("shutil.which", return_value="/usr/bin/docker"):
+                asyncio.run(backend.create_session(_make_config()))
+
+        # The second call is container creation (first is docker version check)
+        create_call = captured_args[1]
+        assert "--runtime" in create_call
+        assert "runsc" in create_call
+        assert "RUNSC_FLAGS=--platform=systrap" in " ".join(create_call)
+
+    def test_create_failure_with_runsc_error(self):
+        """When runsc is not configured, should raise a helpful error."""
+        backend = GVisorSandboxBackend()
+
+        call_count = [0]
+
+        def mock_subprocess(args, **kwargs):
+            call_count[0] += 1
+            mock_proc = MagicMock()
+            if call_count[0] == 1:
+                # docker version check succeeds
+                mock_proc.returncode = 0
+                mock_proc.stdout = "24.0.0"
+                mock_proc.stderr = ""
+            else:
+                # container creation fails with runsc error
+                mock_proc.returncode = 125
+                mock_proc.stdout = ""
+                mock_proc.stderr = "docker: Error response from daemon: runtime runsc not found"
+            return mock_proc
+
+        with patch("subprocess.run", side_effect=mock_subprocess):
+            with patch("shutil.which", return_value="/usr/bin/docker"):
+                with pytest.raises(RuntimeError, match="gVisor runtime 'runsc' is not properly configured"):
+                    asyncio.run(backend.create_session(_make_config()))

--- a/tests/test_sandbox/test_network_policy.py
+++ b/tests/test_sandbox/test_network_policy.py
@@ -1,0 +1,124 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for network policy engine."""
+
+import asyncio
+
+import pytest
+
+from agently.builtins.sandbox.network_policy import (
+    NetworkPolicy,
+    NetworkPolicyEngine,
+    NetworkRule,
+)
+from agently.builtins.sandbox.protocol import SandboxConfig
+
+
+class TestNetworkRule:
+    def test_deny_rule(self):
+        rule = NetworkRule(action="deny", dst="169.254.169.254", reason="cloud_metadata")
+        assert rule.action == "deny"
+        assert rule.dst == "169.254.169.254"
+
+    def test_to_dict(self):
+        rule = NetworkRule(action="allow", dst="api.example.com", reason="allowlisted", port=443)
+        d = rule.to_dict()
+        assert d["action"] == "allow"
+        assert d["port"] == 443
+
+
+class TestNetworkPolicy:
+    def test_completely_blocked(self):
+        policy = NetworkPolicy(rules=[
+            NetworkRule(action="deny", dst="*", reason="network_disabled"),
+        ])
+        assert policy.is_completely_blocked is True
+
+    def test_not_completely_blocked(self):
+        policy = NetworkPolicy(rules=[
+            NetworkRule(action="deny", dst="169.254.169.254", reason="metadata"),
+        ])
+        assert policy.is_completely_blocked is False
+
+    def test_empty_policy_not_blocked(self):
+        policy = NetworkPolicy()
+        assert policy.is_completely_blocked is False
+
+
+class TestNetworkPolicyEngine:
+    @pytest.fixture
+    def engine(self):
+        return NetworkPolicyEngine()
+
+    def test_network_disabled_blocks_all(self, engine):
+        config = SandboxConfig(network_enabled=False)
+        policy = asyncio.run(engine.evaluate(config))
+        assert policy.is_completely_blocked is True
+
+    def test_network_disabled_blocks_metadata(self, engine):
+        config = SandboxConfig(network_enabled=False, block_cloud_metadata=True)
+        policy = asyncio.run(engine.evaluate(config))
+        # Should have metadata blocks + deny-all
+        deny_rules = [r for r in policy.rules if r.action == "deny"]
+        assert len(deny_rules) >= 5  # 4 metadata + 1 deny-all
+
+    def test_allowlist_mode(self, engine):
+        config = SandboxConfig(
+            network_enabled=True,
+            network_allowlist=["api.example.com", "pypi.org"],
+        )
+        policy = asyncio.run(engine.evaluate(config))
+        allow_rules = [r for r in policy.rules if r.action == "allow"]
+        assert len(allow_rules) == 2
+        assert any(r.dst == "api.example.com" for r in allow_rules)
+        assert any(r.dst == "pypi.org" for r in allow_rules)
+        # Should also have a deny-all rule
+        deny_all = [r for r in policy.rules if r.action == "deny" and r.dst == "*"]
+        assert len(deny_all) == 1
+        # is_completely_blocked is True because deny-all exists (allow rules are exceptions)
+        assert policy.is_completely_blocked is True
+
+    def test_network_enabled_no_allowlist(self, engine):
+        config = SandboxConfig(
+            network_enabled=True,
+            block_cloud_metadata=True,
+        )
+        policy = asyncio.run(engine.evaluate(config))
+        # Only metadata blocks, no deny-all
+        assert not any(r.dst == "*" for r in policy.rules)
+        metadata_rules = [r for r in policy.rules if r.action == "deny"]
+        assert len(metadata_rules) == 4  # AWS, GCP, Azure, Alicloud
+
+    def test_metadata_blocking_disabled(self, engine):
+        config = SandboxConfig(
+            network_enabled=True,
+            block_cloud_metadata=False,
+        )
+        policy = asyncio.run(engine.evaluate(config))
+        assert len(policy.rules) == 0
+
+    def test_blocked_endpoints_include_all_cloud_providers(self, engine):
+        assert "169.254.169.254" in NetworkPolicyEngine.BLOCKED_ENDPOINTS
+        assert "100.100.100.200" in NetworkPolicyEngine.BLOCKED_ENDPOINTS
+        assert "metadata.google.internal" in NetworkPolicyEngine.BLOCKED_ENDPOINTS
+        assert "metadata.azure.com" in NetworkPolicyEngine.BLOCKED_ENDPOINTS
+
+    def test_remove_network_args(self):
+        args = ["docker", "run", "--network", "bridge", "--memory", "512m"]
+        result = NetworkPolicyEngine._remove_network_args(args)
+        assert "--network" not in result
+        assert "bridge" not in result
+        assert "--memory" in result
+        assert "512m" in result
+
+    def test_remove_network_args_equals_form(self):
+        args = ["docker", "run", "--network=host", "--memory", "512m"]
+        result = NetworkPolicyEngine._remove_network_args(args)
+        assert "--network=host" not in result
+        assert "--memory" in result

--- a/tests/test_sandbox/test_protocol.py
+++ b/tests/test_sandbox/test_protocol.py
@@ -1,0 +1,118 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for sandbox protocol definitions."""
+
+import pytest
+
+from agently.builtins.sandbox.protocol import (
+    IsolationLevel,
+    SandboxBackend,
+    SandboxConfig,
+    SandboxResult,
+    SandboxSession,
+)
+
+
+class TestIsolationLevel:
+    def test_enum_values(self):
+        assert IsolationLevel.PROCESS == "process"
+        assert IsolationLevel.CONTAINER == "container"
+        assert IsolationLevel.ENHANCED_CONTAINER == "enhanced"
+        assert IsolationLevel.MICROVM == "microvm"
+
+    def test_enum_is_str(self):
+        assert isinstance(IsolationLevel.CONTAINER, str)
+
+
+class TestSandboxConfig:
+    def test_defaults(self):
+        config = SandboxConfig()
+        assert config.image == "python:3.12-slim"
+        assert config.isolation_level == IsolationLevel.CONTAINER
+        assert config.memory_limit == "512m"
+        assert config.cpu_limit == 1.0
+        assert config.timeout == 30
+        assert config.network_enabled is False
+        assert config.block_cloud_metadata is True
+        assert config.read_only_fs is True
+        assert config.drop_capabilities is True
+        assert config.no_new_privileges is True
+        assert config.run_as_user == 1000
+        assert config.gpu_enabled is False
+
+    def test_custom_values(self):
+        config = SandboxConfig(
+            image="node:22-slim",
+            memory_limit="1g",
+            cpu_limit=2.0,
+            network_enabled=True,
+            network_allowlist=["api.example.com"],
+        )
+        assert config.image == "node:22-slim"
+        assert config.memory_limit == "1g"
+        assert config.cpu_limit == 2.0
+        assert config.network_enabled is True
+        assert config.network_allowlist == ["api.example.com"]
+
+    def test_to_dict(self):
+        config = SandboxConfig()
+        d = config.to_dict()
+        assert d["image"] == "python:3.12-slim"
+        assert d["isolation_level"] == "container"
+        assert d["network_enabled"] is False
+        assert "memory_limit" in d
+
+
+class TestSandboxResult:
+    def test_success_result(self):
+        result = SandboxResult(
+            exit_code=0,
+            stdout="hello world",
+            stderr="",
+            execution_time_ms=100.0,
+            sandbox_id="abc123",
+        )
+        assert result.success is True
+        assert result.exit_code == 0
+        assert result.stdout == "hello world"
+
+    def test_failure_result(self):
+        result = SandboxResult(
+            exit_code=1,
+            stdout="",
+            stderr="command not found",
+            execution_time_ms=50.0,
+            sandbox_id="abc123",
+        )
+        assert result.success is False
+
+    def test_to_dict(self):
+        result = SandboxResult(
+            exit_code=0,
+            stdout="output",
+            stderr="",
+            execution_time_ms=10.0,
+            sandbox_id="test-id",
+            truncated=True,
+        )
+        d = result.to_dict()
+        assert d["exit_code"] == 0
+        assert d["stdout"] == "output"
+        assert d["truncated"] is True
+        assert d["sandbox_id"] == "test-id"
+
+
+class TestProtocolCompliance:
+    def test_sandbox_session_is_runtime_checkable(self):
+        """SandboxSession protocol should be runtime-checkable."""
+        assert isinstance(SandboxSession, type)
+
+    def test_sandbox_backend_is_runtime_checkable(self):
+        """SandboxBackend protocol should be runtime-checkable."""
+        assert isinstance(SandboxBackend, type)

--- a/tests/test_sandbox/test_sandbox_action_executor.py
+++ b/tests/test_sandbox/test_sandbox_action_executor.py
@@ -1,0 +1,105 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for SandboxActionExecutor plugin."""
+
+import pytest
+
+from agently.builtins.plugins.ActionExecutor.SandboxActionExecutor import (
+    SandboxActionExecutor,
+)
+
+
+class TestSandboxActionExecutorProtocol:
+    """Verify SandboxActionExecutor conforms to the ActionExecutor protocol."""
+
+    def test_has_name(self):
+        assert SandboxActionExecutor.name == "SandboxActionExecutor"
+
+    def test_has_kind(self):
+        executor = SandboxActionExecutor()
+        assert executor.kind == "sandbox"
+
+    def test_has_sandboxed_true(self):
+        executor = SandboxActionExecutor()
+        assert executor.sandboxed is True
+
+    def test_has_default_settings(self):
+        assert isinstance(SandboxActionExecutor.DEFAULT_SETTINGS, dict)
+        assert "$global" in SandboxActionExecutor.DEFAULT_SETTINGS
+        global_settings = SandboxActionExecutor.DEFAULT_SETTINGS["$global"]
+        assert "sandbox.backend" in global_settings
+        assert "sandbox.default_timeout" in global_settings
+        assert "sandbox.network_enabled" in global_settings
+
+    def test_has_on_register(self):
+        assert hasattr(SandboxActionExecutor, "_on_register")
+
+    def test_has_on_unregister(self):
+        assert hasattr(SandboxActionExecutor, "_on_unregister")
+
+    def test_has_execute_method(self):
+        executor = SandboxActionExecutor()
+        assert hasattr(executor, "execute")
+
+
+class TestSandboxActionExecutorInit:
+    def test_default_init(self):
+        executor = SandboxActionExecutor()
+        assert executor._backend_name == "docker"
+        assert executor._default_image == "python:3.12-slim"
+        assert executor._default_timeout == 30
+        assert executor._network_enabled is False
+
+    def test_custom_init(self):
+        executor = SandboxActionExecutor(
+            backend="gvisor",
+            default_image="node:22-slim",
+            default_timeout=60,
+            network_enabled=True,
+        )
+        assert executor._backend_name == "gvisor"
+        assert executor._default_image == "node:22-slim"
+        assert executor._default_timeout == 60
+        assert executor._network_enabled is True
+
+
+class TestSandboxActionExecutorConfig:
+    def test_build_config_defaults(self):
+        executor = SandboxActionExecutor()
+        config = executor._build_config({}, None)
+        assert config.image == "python:3.12-slim"
+        assert config.timeout == 30
+        assert config.network_enabled is False
+
+    def test_build_config_policy_override(self):
+        executor = SandboxActionExecutor()
+        config = executor._build_config(
+            {"timeout_seconds": 60, "sandbox_image": "custom:latest"},
+            None,
+        )
+        assert config.timeout == 60
+        assert config.image == "custom:latest"
+
+
+class TestSandboxActionExecutorBackendSelection:
+    def test_get_docker_backend(self):
+        executor = SandboxActionExecutor(backend="docker")
+        backend = executor._get_backend()
+        assert backend.name == "DockerSandbox"
+
+    def test_get_gvisor_backend(self):
+        executor = SandboxActionExecutor(backend="gvisor")
+        backend = executor._get_backend()
+        assert backend.name == "GVisorSandbox"
+
+    def test_backend_is_cached(self):
+        executor = SandboxActionExecutor(backend="docker")
+        backend1 = executor._get_backend()
+        backend2 = executor._get_backend()
+        assert backend1 is backend2


### PR DESCRIPTION
## 概述

观察到之前的python沙箱 元函数逃逸相关问题 为了方面集成和控制爆炸半径 是否可以将运行转换到docker 容器或带用户态内核的gvisor 容器代理中执行
PR 集成 Agently fork (`feature/add-sandbox-plugin`) 的沙箱插件系统，验证其与 我自有项目修改后的兼容性 ，并补充 gVisor 运行时测试。

Agently fork 仓库：https://github.com/drscrewdriver/Agently
分支：`feature/add-sandbox-plugin`

## 变更内容

### 1. Agently Fork 沙箱插件集成

安装 Agently fork v4.1.4.1 替换 venv 中的 agently 包，验证以下新模块：

- `agently.builtins.sandbox.protocol` — IsolationLevel, SandboxConfig, SandboxResult, SandboxBackend, SandboxSession
- `agently.builtins.sandbox.docker_backend` — DockerSandboxBackend, DockerSandboxSession
- `agently.builtins.sandbox.gvisor_backend` — GVisorSandboxBackend
- `agently.builtins.sandbox.network_policy` — NetworkPolicyEngine
- `agently.builtins.sandbox.events` — 事件发射器
- `agently.builtins.plugins.ActionExecutor.SandboxActionExecutor` — 统一沙箱执行器

### 2. gVisor 双运行时验证

安装 gVisor (runsc) 运行时，验证 Agently Fork 的 `GVisorSandboxBackend` 在增强隔离模式下正常工作。

### 3. 两套沙箱共存

我自有项目  graph-flow 原生沙箱 (`src.agently_integration.*`) 与 Agently Fork 沙箱 (`agently.builtins.sandbox.*`) 命名空间独立，可同时实例化无冲突。

## 新增文件

| 文件 | 说明 |
|------|------|
| `tests/test_agently_sandbox_plugin.py` | 52 个集成测试 |
| `docs/sandbox-runtime-guide.md` | Docker/gVisor 双运行时配置指南 |
| `scripts/install_gvisor.sh` | gVisor 一键安装脚本 |

## 测试结果

| 测试套件 | 数量 | 状态 |
|----------|------|------|
| 现有沙箱回归测试 | 58 | ✅ 全部通过 |
| Agently Fork 集成测试 | 45 | ✅ 全部通过 |
| gVisor 运行时测试 | 7 | ✅ 全部通过 |
| **总计** | **110** | **✅ 全部通过** |

## 检查清单

- [x] 回归测试通过（58 个现有测试无破坏）
- [x] 新增测试覆盖 Agently Fork 全部沙箱模块
- [x] gVisor 运行时实测通过
- [x] 两套沙箱系统共存验证通过
- [x] 文档已更新