### PR TITLE
Feature/seatbelt provider

### DIFF
--- a/agently/builtins/plugins/ExecutionResourceProvider/SeatbeltExecutionResourceProvider.py
+++ b/agently/builtins/plugins/ExecutionResourceProvider/SeatbeltExecutionResourceProvider.py
@@ -19,6 +19,375 @@ Uses `sandbox-exec` with SBPL (Seatbelt Profile Language) to provide
 kernel-level syscall filtering on macOS, as an alternative to Docker-based
 isolation.
 
+SBPL Profile Design (inspired by OpenHanako):
+- Default deny all
+- Basic capabilities always allowed (process, mach, ipc)
+- File read: globally allowed (system libs needed for command execution)
+- File write: whitelist only (writable_paths + temp dirs)
+- Protected paths: deny write (after allow, last-match-wins)
+- Deny-read paths: deny both read and write
+- Device files: /dev/null, /dev/ptmx, pseudo-tty
+- Network: optional outbound switch
+
+This provider is **only** available on macOS. On other platforms it reports
+itself as unavailable.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Any
+
+from agently.core.operation.ExecutionResource import (
+    ExecutionResource,
+    ExecutionResourceProvider,
+)
+
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+def is_macos() -> bool:
+    """Return True when running on macOS (Darwin)."""
+    return platform.system() == "Darwin"
+
+
+def inspect_seatbelt_availability() -> dict[str, Any]:
+    """Check whether macOS Seatbelt (sandbox-exec) is usable.
+
+    Returns a dict with at least ``{"available": bool}``. When unavailable
+    the dict also contains a ``"reason"`` key.
+    """
+    if not is_macos():
+        return {"available": False, "reason": "not_macos"}
+    binary = shutil.which("sandbox-exec")
+    if binary is None:
+        return {"available": False, "reason": "sandbox_exec_missing"}
+    return {
+        "available": True,
+        "binary": binary,
+        "platform": "macos",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Path utilities
+# ---------------------------------------------------------------------------
+
+def _realpath(path: str) -> str:
+    """Resolve symbolic links to prevent subpath bypass attacks.
+
+    SBPL's (subpath "...") can be bypassed via symlinks if the target
+    is outside the allowed subtree. Resolving to realpath prevents this.
+    """
+    try:
+        return str(Path(path).resolve())
+    except (OSError, ValueError):
+        return path
+
+
+def _get_tmpdir() -> str:
+    """Get the actual temporary directory on macOS."""
+    return os.environ.get("TMPDIR", "/tmp")
+
+
+# ---------------------------------------------------------------------------
+# SBPL profile generation
+# ---------------------------------------------------------------------------
+
+def _build_sbpl_profile(
+    *,
+    network: bool = False,
+    writable_paths: list[str] | None = None,
+    protected_paths: list[str] | None = None,
+    deny_read_paths: list[str] | None = None,
+    extra_rules: str = "",
+) -> str:
+    """Generate an SBPL (Seatbelt Profile Language) profile string.
+
+    Design follows the "last-match-wins" rule: deny rules are placed AFTER
+    allow rules to override them for specific paths.
+
+    Parameters
+    ----------
+    network:
+        Allow network outbound access when True.
+    writable_paths:
+        Filesystem paths where writing is allowed (whitelist).
+    protected_paths:
+        Paths where writing is explicitly denied (e.g., .git directories).
+        These override writable_paths due to last-match-wins.
+    deny_read_paths:
+        Paths where both reading and writing are denied (e.g., secrets).
+    extra_rules:
+        Raw SBPL rule text appended verbatim at the end.
+    """
+    writable_paths = [_realpath(p) for p in (writable_paths or [])]
+    protected_paths = [_realpath(p) for p in (protected_paths or [])]
+    deny_read_paths = [_realpath(p) for p in (deny_read_paths or [])]
+    tmpdir = _get_tmpdir()
+
+    lines: list[str] = [
+        "(version 1)",
+        "(deny default)",
+        "",
+        ";; ═══ Basic capabilities (always allowed) ═══",
+        "(allow process-exec* process-fork signal)",
+        "(allow sysctl-read)",
+        "(allow mach(*))",
+        "(allow ipc-posix*)",
+        "",
+        ";; ═══ File read: globally allowed ═══",
+        ";; AI agents need to read system libs to execute commands",
+        "(allow file-read*)",
+        "",
+        ";; ═══ File write: whitelist only ═══",
+    ]
+
+    # Writable paths (user-specified workspace)
+    for p in writable_paths:
+        lines.append(f'(allow file-write* (subpath "{p}"))')
+
+    # Temporary directories (always writable)
+    lines.append("")
+    lines.append(";; Temporary directories (always writable)")
+    lines.append('(allow file-write* (subpath "/private/tmp"))')
+    lines.append(f'(allow file-write* (subpath "{tmpdir}"))')
+
+    # Device files
+    lines.append("")
+    lines.append(";; Device files + PTY")
+    lines.append('(allow file-write* (literal "/dev/null"))')
+    lines.append('(allow file-write* (regex #"^/dev/ttys[0-9]+$"))')
+    lines.append('(allow file-write* (literal "/dev/ptmx"))')
+    lines.append("(allow pseudo-tty)")
+
+    # Protected paths: deny write (AFTER allow, last-match-wins)
+    if protected_paths:
+        lines.append("")
+        lines.append(";; Protected paths: deny write (overrides allow)")
+        for p in protected_paths:
+            lines.append(f'(deny file-write* (subpath "{p}"))')
+
+    # Deny-read paths: deny both read and write
+    if deny_read_paths:
+        lines.append("")
+        lines.append(";; Deny-read paths: deny both read and write")
+        for p in deny_read_paths:
+            lines.append(f'(deny file-read* (subpath "{p}"))')
+            lines.append(f'(deny file-write* (subpath "{p}"))')
+
+    # Network switch
+    lines.append("")
+    if network:
+        lines.append(";; Network: allow outbound")
+        lines.append("(allow network-outbound)")
+    else:
+        lines.append(";; Network: completely denied")
+        lines.append("(deny network)")
+
+    # Extra rules (verbatim)
+    if extra_rules.strip():
+        lines.append("")
+        lines.append(";; Extra rules")
+        lines.append(extra_rules.strip())
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# SeatbeltExecutionResource
+# ---------------------------------------------------------------------------
+
+class SeatbeltExecutionResource(ExecutionResource):
+    """Execute Python code inside a macOS Seatbelt sandbox.
+
+    The sandbox profile follows these principles:
+    - File read: globally allowed (needed for system libs)
+    - File write: whitelist only (writable_paths + temp dirs)
+    - Protected paths: deny write (overrides writable_paths)
+    - Deny-read paths: deny both read and write (for secrets)
+    - Network: optional outbound switch
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout: int = 60,
+        network: bool = False,
+        writable_paths: list[str] | None = None,
+        protected_paths: list[str] | None = None,
+        deny_read_paths: list[str] | None = None,
+        extra_sbpl_rules: str = "",
+        python_binary: str = "python3",
+    ):
+        self.timeout = timeout
+        self.network = network
+        self.writable_paths = writable_paths or []
+        self.protected_paths = protected_paths or []
+        self.deny_read_paths = deny_read_paths or []
+        self.extra_sbpl_rules = extra_sbpl_rules
+        self.python_binary = python_binary
+
+    # -- availability -------------------------------------------------------
+
+    def inspect_availability(self) -> dict[str, Any]:
+        return inspect_seatbelt_availability()
+
+    # -- SBPL profile -------------------------------------------------------
+
+    def build_profile(self) -> str:
+        """Generate the SBPL profile for this sandbox session."""
+        return _build_sbpl_profile(
+            network=self.network,
+            writable_paths=self.writable_paths,
+            protected_paths=self.protected_paths,
+            deny_read_paths=self.deny_read_paths,
+            extra_rules=self.extra_sbpl_rules,
+        )
+
+    # -- execution ----------------------------------------------------------
+
+    async def run_python_code(
+        self,
+        *,
+        python_code: str,
+        timeout: int | None = None,
+    ) -> dict[str, Any]:
+        effective_timeout = timeout or self.timeout
+        profile_text = self.build_profile()
+
+        cmd = [
+            "sandbox-exec", "-f", "-",
+            self.python_binary, "-c", python_code,
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                input=profile_text,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "ok": False,
+                "error": f"Seatbelt sandbox timed out after {effective_timeout}s",
+                "stdout": "",
+                "stderr": "",
+            }
+        except FileNotFoundError:
+            return {
+                "ok": False,
+                "error": "sandbox-exec binary not found (macOS only)",
+                "stdout": "",
+                "stderr": "",
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "error": str(exc),
+                "stdout": "",
+                "stderr": "",
+            }
+
+        return {
+            "ok": result.returncode == 0,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+
+
+# ---------------------------------------------------------------------------
+# SeatbeltExecutionResourceProvider
+# ---------------------------------------------------------------------------
+
+class SeatbeltExecutionResourceProvider(ExecutionResourceProvider):
+    """Provider that creates Seatbelt-sandboxed execution resources.
+
+    Registered with ``kind="seatbelt"``. Only functional on macOS.
+    """
+
+    @property
+    def name(self) -> str:
+        return "seatbelt"
+
+    @property
+    def kind(self) -> str:
+        return "seatbelt"
+
+    def inspect_availability(self) -> dict[str, Any]:
+        return inspect_seatbelt_availability()
+
+    def create_handle(
+        self,
+        *,
+        config: dict[str, Any],
+        policy: dict[str, Any],
+    ) -> dict[str, Any]:
+        availability = inspect_seatbelt_availability()
+        if not availability.get("available"):
+            return {
+                "handle_id": f"seatbelt:{uuid.uuid4().hex}",
+                "resource": None,
+                "availability": availability,
+                "meta": {
+                    "provider": self.name,
+                    "available": False,
+                    "reason": availability.get("reason", "unknown"),
+                },
+            }
+
+        resource = SeatbeltExecutionResource(
+            timeout=int(policy.get("timeout_seconds", config.get("timeout", 60))),
+            network=bool(config.get("network", False)),
+            writable_paths=[str(p) for p in config.get("writable_paths", [])],
+            protected_paths=[str(p) for p in config.get("protected_paths", [])],
+            deny_read_paths=[str(p) for p in config.get("deny_read_paths", [])],
+            extra_sbpl_rules=str(config.get("extra_sbpl_rules", "")),
+            python_binary=str(config.get("python_binary", "python3")),
+        )
+
+        return {
+            "handle_id": f"seatbelt:{uuid.uuid4().hex}",
+            "resource": resource,
+            "availability": availability,
+            "meta": {
+                "provider": self.name,
+                "available": True,
+                "platform": "macos",
+                "network": resource.network,
+            },
+        }
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+SeatbeltExecutionResourceProvider — macOS Seatbelt sandbox backend.
+
+Uses `sandbox-exec` with SBPL (Seatbelt Profile Language) to provide
+kernel-level syscall filtering on macOS, as an alternative to Docker-based
+isolation.
+
 This provider is **only** available on macOS.  On other platforms it reports
 itself as unavailable and the ExecutionResourceManager will refuse to create
 handles for it.

--- a/agently/builtins/plugins/ExecutionResourceProvider/SeatbeltExecutionResourceProvider.py
+++ b/agently/builtins/plugins/ExecutionResourceProvider/SeatbeltExecutionResourceProvider.py
@@ -1,0 +1,290 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+SeatbeltExecutionResourceProvider — macOS Seatbelt sandbox backend.
+
+Uses `sandbox-exec` with SBPL (Seatbelt Profile Language) to provide
+kernel-level syscall filtering on macOS, as an alternative to Docker-based
+isolation.
+
+This provider is **only** available on macOS.  On other platforms it reports
+itself as unavailable and the ExecutionResourceManager will refuse to create
+handles for it.
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+import uuid
+from typing import Any
+
+from agently.core.operation.ExecutionResource import (
+    ExecutionResource,
+    ExecutionResourceProvider,
+)
+
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+def is_macos() -> bool:
+    """Return True when running on macOS (Darwin)."""
+    return platform.system() == "Darwin"
+
+
+def inspect_seatbelt_availability() -> dict[str, Any]:
+    """Check whether macOS Seatbelt (sandbox-exec) is usable.
+
+    Returns a dict with at least ``{"available": bool}``.  When unavailable
+    the dict also contains a ``"reason"`` key.
+    """
+    if not is_macos():
+        return {"available": False, "reason": "not_macos"}
+    binary = shutil.which("sandbox-exec")
+    if binary is None:
+        return {"available": False, "reason": "sandbox_exec_missing"}
+    return {
+        "available": True,
+        "binary": binary,
+        "platform": "macos",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SBPL profile generation
+# ---------------------------------------------------------------------------
+
+def _build_sbpl_profile(
+    *,
+    network: bool = False,
+    read_paths: list[str] | None = None,
+    write_paths: list[str] | None = None,
+    extra_rules: str = "",
+) -> str:
+    """Generate an SBPL (Seatbelt Profile Language) profile string.
+
+    Parameters
+    ----------
+    network:
+        Allow network access when *True*.
+    read_paths:
+        Extra filesystem paths allowed for reading.
+    write_paths:
+        Extra filesystem paths allowed for writing.
+    extra_rules:
+        Raw SBPL rule text appended verbatim.
+    """
+    read_paths = read_paths or []
+    write_paths = write_paths or []
+
+    lines: list[str] = [
+        "(version 1)",
+        "(deny default)",
+        "",
+        "# Always allow basic process operations",
+        "(allow process-exec)",
+        "(allow signal (target same-sandbox))",
+        "(allow sysctl-read)",
+        "",
+        "# Filesystem — deny by default, selectively allow",
+        "(allow file-read* (subpath \"/usr/lib\")",
+        "                 (subpath \"/usr/share\")",
+        "                 (subpath \"/Library/Frameworks\")",
+        "                 (subpath \"/System/Library/Frameworks\"))",
+    ]
+
+    for p in read_paths:
+        lines.append(f'(allow file-read* (subpath "{p}"))')
+
+    for p in write_paths:
+        lines.append(f'(allow file-write* (subpath "{p}"))')
+
+    if network:
+        lines.extend([
+            "",
+            "# Network access",
+            "(allow network*)",
+        ])
+    else:
+        lines.extend([
+            "",
+            "# Network denied (default)",
+            "(deny network*)",
+        ])
+
+    if extra_rules.strip():
+        lines.append("")
+        lines.append("# Extra rules")
+        lines.append(extra_rules.strip())
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# SeatbeltExecutionResource
+# ---------------------------------------------------------------------------
+
+class SeatbeltExecutionResource(ExecutionResource):
+    """Execute Python code inside a macOS Seatbelt sandbox."""
+
+    def __init__(
+        self,
+        *,
+        timeout: int = 60,
+        network: bool = False,
+        read_paths: list[str] | None = None,
+        write_paths: list[str] | None = None,
+        extra_sbpl_rules: str = "",
+        python_binary: str = "python3",
+    ):
+        self.timeout = timeout
+        self.network = network
+        self.read_paths = read_paths or []
+        self.write_paths = write_paths or []
+        self.extra_sbpl_rules = extra_sbpl_rules
+        self.python_binary = python_binary
+
+    # -- availability -------------------------------------------------------
+
+    def inspect_availability(self) -> dict[str, Any]:
+        return inspect_seatbelt_availability()
+
+    # -- SBPL profile -------------------------------------------------------
+
+    def build_profile(self) -> str:
+        return _build_sbpl_profile(
+            network=self.network,
+            read_paths=self.read_paths,
+            write_paths=self.write_paths,
+            extra_rules=self.extra_sbpl_rules,
+        )
+
+    # -- execution ----------------------------------------------------------
+
+    async def run_python_code(
+        self,
+        *,
+        python_code: str,
+        timeout: int | None = None,
+    ) -> dict[str, Any]:
+        effective_timeout = timeout or self.timeout
+        profile_text = self.build_profile()
+
+        cmd = [
+            "sandbox-exec", "-f", "-",
+            self.python_binary, "-c", python_code,
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                input=profile_text,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "ok": False,
+                "error": f"Seatbelt sandbox timed out after {effective_timeout}s",
+                "stdout": "",
+                "stderr": "",
+            }
+        except FileNotFoundError:
+            return {
+                "ok": False,
+                "error": "sandbox-exec binary not found (macOS only)",
+                "stdout": "",
+                "stderr": "",
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "error": str(exc),
+                "stdout": "",
+                "stderr": "",
+            }
+
+        return {
+            "ok": result.returncode == 0,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+
+
+# ---------------------------------------------------------------------------
+# SeatbeltExecutionResourceProvider
+# ---------------------------------------------------------------------------
+
+class SeatbeltExecutionResourceProvider(ExecutionResourceProvider):
+    """Provider that creates Seatbelt-sandboxed execution resources.
+
+    Registered with ``kind="seatbelt"``.  Only functional on macOS.
+    """
+
+    @property
+    def name(self) -> str:
+        return "seatbelt"
+
+    @property
+    def kind(self) -> str:
+        return "seatbelt"
+
+    def inspect_availability(self) -> dict[str, Any]:
+        return inspect_seatbelt_availability()
+
+    def create_handle(
+        self,
+        *,
+        config: dict[str, Any],
+        policy: dict[str, Any],
+    ) -> dict[str, Any]:
+        availability = inspect_seatbelt_availability()
+        if not availability.get("available"):
+            return {
+                "handle_id": f"seatbelt:{uuid.uuid4().hex}",
+                "resource": None,
+                "availability": availability,
+                "meta": {
+                    "provider": self.name,
+                    "available": False,
+                    "reason": availability.get("reason", "unknown"),
+                },
+            }
+
+        resource = SeatbeltExecutionResource(
+            timeout=int(policy.get("timeout_seconds", config.get("timeout", 60))),
+            network=bool(config.get("network", False)),
+            read_paths=[str(p) for p in config.get("read_paths", [])],
+            write_paths=[str(p) for p in config.get("write_paths", [])],
+            extra_sbpl_rules=str(config.get("extra_sbpl_rules", "")),
+            python_binary=str(config.get("python_binary", "python3")),
+        )
+
+        return {
+            "handle_id": f"seatbelt:{uuid.uuid4().hex}",
+            "resource": resource,
+            "availability": availability,
+            "meta": {
+                "provider": self.name,
+                "available": True,
+                "platform": "macos",
+                "network": resource.network,
+            },
+        }

--- a/agently/builtins/plugins/ExecutionResourceProvider/__init__.py
+++ b/agently/builtins/plugins/ExecutionResourceProvider/__init__.py
@@ -6,3 +6,4 @@ from .NodeExecutionResourceProvider import NodeExecutionResourceProvider
 from .DockerExecutionResourceProvider import DockerExecutionResourceProvider
 from .BrowserExecutionResourceProvider import BrowserExecutionResourceProvider
 from .SQLiteExecutionResourceProvider import SQLiteExecutionResourceProvider
+from .SeatbeltExecutionResourceProvider import SeatbeltExecutionResourceProvider

--- a/agently/builtins/plugins/ExecutionResourceProvider/__init__.py
+++ b/agently/builtins/plugins/ExecutionResourceProvider/__init__.py
@@ -1,3 +1,5 @@
+import platform
+
 from .ACPExecutionResourceProvider import ACPExecutionResourceProvider
 from .BashExecutionResourceProvider import BashExecutionResourceProvider
 from .MCPExecutionResourceProvider import MCPExecutionResourceProvider
@@ -6,4 +8,7 @@ from .NodeExecutionResourceProvider import NodeExecutionResourceProvider
 from .DockerExecutionResourceProvider import DockerExecutionResourceProvider
 from .BrowserExecutionResourceProvider import BrowserExecutionResourceProvider
 from .SQLiteExecutionResourceProvider import SQLiteExecutionResourceProvider
-from .SeatbeltExecutionResourceProvider import SeatbeltExecutionResourceProvider
+
+# Seatbelt is macOS-only; only import when running on Darwin
+if platform.system() == "Darwin":
+    from .SeatbeltExecutionResourceProvider import SeatbeltExecutionResourceProvider

--- a/agently/core/operation/Action/ActionResourceRegistrar.py
+++ b/agently/core/operation/Action/ActionResourceRegistrar.py
@@ -35,13 +35,13 @@ class ActionResourceRegistrar:
         self._action = action
 
     @staticmethod
-    def _normalize_code_sandbox(value: Literal["auto", "docker", "trusted_local"] | str) -> Literal["auto", "docker", "trusted_local"]:
+    def _normalize_code_sandbox(value: Literal["auto", "docker", "seatbelt", "trusted_local"] | str) -> Literal["auto", "docker", "seatbelt", "trusted_local"]:
         normalized = str(value or "trusted_local").strip().lower().replace("-", "_")
         if normalized in {"local", "python", "node", "bash"}:
             normalized = "trusted_local"
-        if normalized not in {"auto", "docker", "trusted_local"}:
-            raise ValueError("sandbox must be one of: 'auto', 'docker', 'trusted_local'.")
-        return cast(Literal["auto", "docker", "trusted_local"], normalized)
+        if normalized not in {"auto", "docker", "seatbelt", "trusted_local"}:
+            raise ValueError("sandbox must be one of: 'auto', 'docker', 'seatbelt', 'trusted_local'.")
+        return cast(Literal["auto", "docker", "seatbelt", "trusted_local"], normalized)
 
     @staticmethod
     def _normalize_dependency_policy(value: Literal["deny", "request", "install"] | dict[str, Any] | str) -> dict[str, Any]:
@@ -649,6 +649,64 @@ class ActionResourceRegistrar:
                     "config": {
                         "database": database,
                         "uri": uri,
+                    },
+                    "policy": cast(ExecutionResourcePolicy, merged_policy),
+                }
+            ]),
+        )
+        return action
+
+    # ------------------------------------------------------------------
+    # Seatbelt sandbox registration (macOS only)
+    # ------------------------------------------------------------------
+
+    def register_seatbelt_sandbox_action(
+        self,
+        *,
+        action_id: str = "seatbelt_sandbox",
+        desc: str = "Execute Python code inside a macOS Seatbelt sandbox (sandbox-exec + SBPL).",
+        tags: str | list[str] | None = None,
+        default_policy: "ActionPolicy | None" = None,
+        expose_to_model: bool = False,
+        network: bool = False,
+        read_paths: list[str] | None = None,
+        write_paths: list[str] | None = None,
+        extra_sbpl_rules: str = "",
+        timeout: int = 60,
+    ):
+        """Register a Python sandbox action backed by macOS Seatbelt.
+
+        Only available on macOS. On other platforms the provider will
+        report itself as unavailable at handle-creation time.
+        """
+        action = self._action.register_action(
+            action_id=action_id,
+            desc=desc,
+            tags=tags,
+            default_policy=default_policy,
+            expose_to_model=expose_to_model,
+        )
+
+        merged_policy = self._merge_action_policy(
+            action_policy=default_policy,
+            timeout=timeout,
+        )
+
+        action.bind_execution(
+            default_policy=merged_policy,
+            side_effect_level="read",
+            execution_resources=cast(list[ExecutionResourceRequirement], [
+                {
+                    "requirement_id": f"seatbelt:{ action_id }",
+                    "kind": "seatbelt",
+                    "scope": "action_call",
+                    "resource_key": action_id,
+                    "config": {
+                        "timeout": timeout,
+                        "network": network,
+                        "read_paths": read_paths or [],
+                        "write_paths": write_paths or [],
+                        "extra_sbpl_rules": extra_sbpl_rules,
                     },
                     "policy": cast(ExecutionResourcePolicy, merged_policy),
                 }

--- a/agently/core/operation/Action/ActionResourceRegistrar.py
+++ b/agently/core/operation/Action/ActionResourceRegistrar.py
@@ -669,12 +669,20 @@ class ActionResourceRegistrar:
         default_policy: "ActionPolicy | None" = None,
         expose_to_model: bool = False,
         network: bool = False,
-        read_paths: list[str] | None = None,
-        write_paths: list[str] | None = None,
+        writable_paths: list[str] | None = None,
+        protected_paths: list[str] | None = None,
+        deny_read_paths: list[str] | None = None,
         extra_sbpl_rules: str = "",
         timeout: int = 60,
     ):
         """Register a Python sandbox action backed by macOS Seatbelt.
+
+        SBPL Profile Design:
+        - File read: globally allowed (needed for system libs)
+        - File write: whitelist only (writable_paths + temp dirs)
+        - Protected paths: deny write (overrides writable_paths, last-match-wins)
+        - Deny-read paths: deny both read and write (for secrets)
+        - Network: optional outbound switch
 
         Only available on macOS. On other platforms the provider will
         report itself as unavailable at handle-creation time.
@@ -704,8 +712,9 @@ class ActionResourceRegistrar:
                     "config": {
                         "timeout": timeout,
                         "network": network,
-                        "read_paths": read_paths or [],
-                        "write_paths": write_paths or [],
+                        "writable_paths": writable_paths or [],
+                        "protected_paths": protected_paths or [],
+                        "deny_read_paths": deny_read_paths or [],
                         "extra_sbpl_rules": extra_sbpl_rules,
                     },
                     "policy": cast(ExecutionResourcePolicy, merged_policy),

--- a/docs/cn/seatbelt/README.md
+++ b/docs/cn/seatbelt/README.md
@@ -1,0 +1,225 @@
+# Seatbelt Sandbox Provider
+
+> **Platform**: macOS only  
+> **Language**: [English](../../en/seatbelt/README.md) · **中文**
+
+---
+
+## 概述
+
+Seatbelt 是 macOS 自带的内核级沙箱机制，通过 `sandbox-exec` 工具和 SBPL (Seatbelt Profile Language) 实现系统调用过滤。
+
+本 Provider 将 Seatbelt 集成为 Agently 的 `ExecutionResourceProvider`，为代码执行提供轻量级、无需 Docker 的隔离环境。
+
+---
+
+## 核心特性
+
+| 特性 | 说明 |
+|------|------|
+| **零依赖** | 使用 macOS 自带工具，无需安装 Docker |
+| **内核级隔离** | 通过 SBPL 实现 syscall 过滤 |
+| **灵活策略** | 支持白名单写入、受保护路径、禁止读取路径 |
+| **last-match-wins** | SBPL 规则按顺序匹配，后定义的规则覆盖前面的 |
+
+---
+
+## SBPL Profile 设计
+
+Profile 遵循以下设计原则（借鉴 OpenHanako）：
+
+```sbpl
+(version 1)
+(deny default)
+
+;; ═══ 基础能力（始终放行）═══
+(allow process-exec* process-fork signal)
+(allow sysctl-read)
+(allow mach(*))
+(allow ipc-posix*)
+
+;; ═══ 文件读取：全局允许 ═══
+;; AI agent 需要读系统库才能执行命令
+(allow file-read*)
+
+;; ═══ 文件写入：白名单 ═══
+(allow file-write* (subpath "/workspace"))
+(allow file-write* (subpath "/private/tmp"))
+(allow file-write* (subpath "$TMPDIR"))
+
+;; ═══ 设备文件 ═══
+(allow file-write* (literal "/dev/null"))
+(allow file-write* (literal "/dev/ptmx"))
+(allow pseudo-tty)
+
+;; ═══ 受保护路径（last-match-wins）═══
+(deny file-write* (subpath "/workspace/.git"))
+
+;; ═══ 禁止读取（保护 secrets）═══
+(deny file-read* (subpath "/home/user/.env"))
+(deny file-write* (subpath "/home/user/.env"))
+
+;; ═══ 网络开关 ═══
+(allow network-outbound)  ;; 或 (deny network)
+```
+
+---
+
+## 配置参数
+
+### `register_seatbelt_sandbox_action()` 参数
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `action_id` | `str` | `"seatbelt_sandbox"` | Action 标识符 |
+| `network` | `bool` | `False` | 是否允许网络出站 |
+| `writable_paths` | `list[str]` | `[]` | 可写路径白名单 |
+| `protected_paths` | `list[str]` | `[]` | 受保护路径（禁止写入，覆盖 writable_paths） |
+| `deny_read_paths` | `list[str]` | `[]` | 禁止读取路径（同时禁止读写） |
+| `extra_sbpl_rules` | `str` | `""` | 额外的 SBPL 规则（原样追加） |
+| `timeout` | `int` | `60` | 执行超时（秒） |
+
+---
+
+## 使用示例
+
+### 基础用法
+
+```python
+import agently
+
+agent = agently.create_agent()
+
+# 注册 Seatbelt 沙箱 action
+agent.register_seatbelt_sandbox_action(
+    action_id="safe_python",
+    writable_paths=["/tmp/workspace"],
+    protected_paths=["/tmp/workspace/.git"],
+    network=False,
+)
+
+# 使用沙箱执行代码
+result = agent.safe_python({
+    "code": "print('Hello from Seatbelt sandbox!')"
+})
+```
+
+### 保护敏感文件
+
+```python
+agent.register_seatbelt_sandbox_action(
+    action_id="restricted_sandbox",
+    writable_paths=["/workspace"],
+    protected_paths=["/workspace/.git", "/workspace/config"],
+    deny_read_paths=["/home/user/.env", "/home/user/.ssh"],
+    network=False,
+)
+```
+
+### 允许网络访问
+
+```python
+agent.register_seatbelt_sandbox_action(
+    action_id="network_sandbox",
+    writable_paths=["/workspace"],
+    network=True,  # 允许 HTTP 请求
+)
+```
+
+### 自定义 SBPL 规则
+
+```python
+agent.register_seatbelt_sandbox_action(
+    action_id="custom_sandbox",
+    writable_paths=["/workspace"],
+    extra_sbpl_rules="""
+;; 禁止访问特定 Mach 服务
+(deny mach-lookup (global-name "com.apple.security.cryptd"))
+;; 限制进程信息访问
+(deny process-info*)
+""",
+)
+```
+
+---
+
+## 路径安全
+
+### realpath 防绕过
+
+所有路径在写入 SBPL 前都会经过 `realpath()` 解析，防止通过符号链接绕过 `subpath` 限制：
+
+```python
+# 如果 /tmp/link -> /etc，则：
+# (subpath "/tmp/link") 会被解析为 (subpath "/etc")
+# 防止攻击者通过符号链接访问受保护路径
+```
+
+---
+
+## 可用性检测
+
+```python
+from agently.builtins.plugins.ExecutionResourceProvider.SeatbeltExecutionResourceProvider import (
+    inspect_seatbelt_availability,
+    is_macos,
+)
+
+# 检查是否在 macOS
+print(is_macos())  # True/False
+
+# 检查 Seatbelt 可用性
+result = inspect_seatbelt_availability()
+print(result)
+# {'available': True, 'binary': '/usr/bin/sandbox-exec', 'platform': 'macos'}
+```
+
+---
+
+## 条件加载
+
+Provider 仅在 macOS 上加载（通过 `__init__.py` 条件导入）：
+
+```python
+# agently/builtins/plugins/ExecutionResourceProvider/__init__.py
+import platform
+
+if platform.system() == "Darwin":
+    from .SeatbeltExecutionResourceProvider import SeatbeltExecutionResourceProvider
+```
+
+非 macOS 平台不会加载此模块，零开销。
+
+---
+
+## 与 Docker Provider 对比
+
+| 维度 | Seatbelt | Docker |
+|------|----------|--------|
+| **平台** | macOS only | 跨平台 |
+| **依赖** | 无（系统自带） | 需要 Docker |
+| **隔离级别** | syscall 过滤 | namespace + cgroup |
+| **启动速度** | 极快（无容器） | 较慢（需启动容器） |
+| **文件系统** | 共享宿主 | 独立文件系统 |
+| **网络隔离** | 可选开关 | 完全隔离 |
+| **适用场景** | macOS 开发环境 | 生产/CI 环境 |
+
+---
+
+## 限制
+
+1. **仅 macOS**：非 macOS 平台无法使用
+2. **文件读取全局允许**：AI agent 需要读系统库，无法完全限制读取
+3. **网络无域名白名单**：只有全局开关，无法按域名过滤
+4. **无 IPC 限制**：当前未限制跨进程通信
+
+---
+
+## 相关文档
+
+- [ExecutionResource 概览](../actions/execution-environment.md)
+- [多平台沙箱扩展框架](../sandbox-extension-framework.md)
+
+---
+
+> 语言：[English](../../en/seatbelt/README.md) · **中文**

--- a/docs/en/seatbelt/README.md
+++ b/docs/en/seatbelt/README.md
@@ -1,0 +1,225 @@
+# Seatbelt Sandbox Provider
+
+> **Platform**: macOS only  
+> **Language**: **English** · [中文](../../cn/seatbelt/README.md)
+
+---
+
+## Overview
+
+Seatbelt is macOS's built-in kernel-level sandbox mechanism, implementing system call filtering through the `sandbox-exec` tool and SBPL (Seatbelt Profile Language).
+
+This Provider integrates Seatbelt as an Agently `ExecutionResourceProvider`, providing lightweight, Docker-free isolation for code execution.
+
+---
+
+## Core Features
+
+| Feature | Description |
+|---------|-------------|
+| **Zero Dependencies** | Uses macOS built-in tools, no Docker required |
+| **Kernel-level Isolation** | Syscall filtering via SBPL |
+| **Flexible Policies** | Supports whitelist writes, protected paths, deny-read paths |
+| **last-match-wins** | SBPL rules match in order; later rules override earlier ones |
+
+---
+
+## SBPL Profile Design
+
+The profile follows these design principles (inspired by OpenHanako):
+
+```sbpl
+(version 1)
+(deny default)
+
+;; ═══ Basic capabilities (always allowed) ═══
+(allow process-exec* process-fork signal)
+(allow sysctl-read)
+(allow mach(*))
+(allow ipc-posix*)
+
+;; ═══ File read: globally allowed ═══
+;; AI agents need to read system libs to execute commands
+(allow file-read*)
+
+;; ═══ File write: whitelist only ═══
+(allow file-write* (subpath "/workspace"))
+(allow file-write* (subpath "/private/tmp"))
+(allow file-write* (subpath "$TMPDIR"))
+
+;; ═══ Device files ═══
+(allow file-write* (literal "/dev/null"))
+(allow file-write* (literal "/dev/ptmx"))
+(allow pseudo-tty)
+
+;; ═══ Protected paths (last-match-wins) ═══
+(deny file-write* (subpath "/workspace/.git"))
+
+;; ═══ Deny-read (protect secrets) ═══
+(deny file-read* (subpath "/home/user/.env"))
+(deny file-write* (subpath "/home/user/.env"))
+
+;; ═══ Network switch ═══
+(allow network-outbound)  ;; or (deny network)
+```
+
+---
+
+## Configuration Parameters
+
+### `register_seatbelt_sandbox_action()` Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `action_id` | `str` | `"seatbelt_sandbox"` | Action identifier |
+| `network` | `bool` | `False` | Allow network outbound access |
+| `writable_paths` | `list[str]` | `[]` | Whitelist of writable paths |
+| `protected_paths` | `list[str]` | `[]` | Protected paths (deny write, overrides writable_paths) |
+| `deny_read_paths` | `list[str]` | `[]` | Deny-read paths (deny both read and write) |
+| `extra_sbpl_rules` | `str` | `""` | Extra SBPL rules (appended verbatim) |
+| `timeout` | `int` | `60` | Execution timeout (seconds) |
+
+---
+
+## Usage Examples
+
+### Basic Usage
+
+```python
+import agently
+
+agent = agently.create_agent()
+
+# Register Seatbelt sandbox action
+agent.register_seatbelt_sandbox_action(
+    action_id="safe_python",
+    writable_paths=["/tmp/workspace"],
+    protected_paths=["/tmp/workspace/.git"],
+    network=False,
+)
+
+# Execute code in sandbox
+result = agent.Safe_python({
+    "code": "print('Hello from Seatbelt sandbox!')"
+})
+```
+
+### Protect Sensitive Files
+
+```python
+agent.register_seatbelt_sandbox_action(
+    action_id="restricted_sandbox",
+    writable_paths=["/workspace"],
+    protected_paths=["/workspace/.git", "/workspace/config"],
+    deny_read_paths=["/home/user/.env", "/home/user/.ssh"],
+    network=False,
+)
+```
+
+### Allow Network Access
+
+```python
+agent.register_seatbelt_sandbox_action(
+    action_id="network_sandbox",
+    writable_paths=["/workspace"],
+    network=True,  # Allow HTTP requests
+)
+```
+
+### Custom SBPL Rules
+
+```python
+agent.register_seatbelt_sandbox_action(
+    action_id="custom_sandbox",
+    writable_paths=["/workspace"],
+    extra_sbpl_rules="""
+;; Deny access to specific Mach services
+(deny mach-lookup (global-name "com.apple.security.cryptd"))
+;; Restrict process info access
+(deny process-info*)
+""",
+)
+```
+
+---
+
+## Path Security
+
+### realpath Bypass Prevention
+
+All paths are resolved via `realpath()` before being written to SBPL, preventing symlink-based bypass of `subpath` restrictions:
+
+```python
+# If /tmp/link -> /etc, then:
+# (subpath "/tmp/link") is resolved to (subpath "/etc")
+# Prevents attackers from accessing protected paths via symlinks
+```
+
+---
+
+## Availability Detection
+
+```python
+from agently.builtins.plugins.ExecutionResourceProvider.SeatbeltExecutionResourceProvider import (
+    inspect_seatbelt_availability,
+    is_macos,
+)
+
+# Check if running on macOS
+print(is_macos())  # True/False
+
+# Check Seatbelt availability
+result = inspect_seatbelt_availability()
+print(result)
+# {'available': True, 'binary': '/usr/bin/sandbox-exec', 'platform': 'macos'}
+```
+
+---
+
+## Conditional Loading
+
+The Provider is only loaded on macOS (via conditional import in `__init__.py`):
+
+```python
+# agently/builtins/plugins/ExecutionResourceProvider/__init__.py
+import platform
+
+if platform.system() == "Darwin":
+    from .SeatbeltExecutionResourceProvider import SeatbeltExecutionResourceProvider
+```
+
+Non-macOS platforms will not load this module, resulting in zero overhead.
+
+---
+
+## Comparison with Docker Provider
+
+| Dimension | Seatbelt | Docker |
+|-----------|----------|--------|
+| **Platform** | macOS only | Cross-platform |
+| **Dependencies** | None (system built-in) | Requires Docker |
+| **Isolation Level** | Syscall filtering | Namespace + cgroup |
+| **Startup Speed** | Very fast (no container) | Slower (container startup) |
+| **Filesystem** | Shared with host | Independent filesystem |
+| **Network Isolation** | Optional switch | Full isolation |
+| **Use Case** | macOS development | Production/CI environments |
+
+---
+
+## Limitations
+
+1. **macOS Only**: Cannot be used on non-macOS platforms
+2. **File Read Globally Allowed**: AI agents need to read system libs; cannot fully restrict reads
+3. **No Domain-based Network Filtering**: Only global on/off switch, no per-domain filtering
+4. **No IPC Restrictions**: Cross-process communication is not currently restricted
+
+---
+
+## Related Documentation
+
+- [ExecutionResource Overview](../actions/execution-environment.md)
+- [Multi-Platform Sandbox Extension Framework](../sandbox-extension-framework.md)
+
+---
+
+> Language: **English** · [中文](../../cn/seatbelt/README.md)


### PR DESCRIPTION
---

## PR 2: `feature/seatbelt-provider`

### 验证结果

| 验证项 | 结果 |
|--------|------|
| 条件导入（Linux 不加载 Seatbelt） | PASS |
| `_normalize_code_sandbox('seatbelt')` | PASS |
| `register_seatbelt_sandbox_action` 方法存在 | PASS |
| SBPL profile 生成（deny default / whitelist write / protected / deny-read） | PASS |
| 网络开关 | PASS |
| Provider `name`/`kind` 属性 | PASS |
| `create_handle` 在 Linux 返回 unavailable | PASS |
| 现有测试无新增失败 | PASS |
| **文件拼接 bug（659 行应为 369 行）** | **FAIL - 需修复** |
| **`ExecutionResourceProvider` 基类在上游不存在** | **FAIL - 需适配** |
| **`create_handle` 接口与上游 `async_ensure` 不匹配** | **FAIL - 需适配** |

### PR 说明（含待修复问题）

```markdown
## feat: Seatbelt (macOS) ExecutionResourceProvider

### Summary

新增 macOS Seatbelt 沙箱后端，通过 `sandbox-exec` + SBPL (Seatbelt 
Profile Language) 提供内核级系统调用过滤，作为 Docker 隔离的轻量替代。
仅需 macOS，零外部依赖。

### Changes

| File | +/- | Description |
|------|-----|-------------|
| `SeatbeltExecutionResourceProvider.py` | +369 | 新文件：SeatbeltExecutionResource + SeatbeltExecutionResourceProvider |
| `ExecutionResourceProvider/__init__.py` | +6 | 条件导入（仅 Darwin 平台加载） |
| `ActionResourceRegistrar.py` | +75 / -4 | `_normalize_code_sandbox` 新增 `"seatbelt"`；新增 `register_seatbelt_sandbox_action` |
| `docs/cn/seatbelt/README.md` | +225 | 中文说明文档 |
| `docs/en/seatbelt/README.md` | +225 | 英文说明文档 |

### SBPL Profile Design (inspired by OpenHanako)

- **Default deny all** → 最小权限原则
- **基础能力**：process-exec*, process-fork, signal, mach(*), ipc-posix*
- **文件读取**：全局允许（AI agent 需读系统库执行命令）
- **文件写入**：白名单模式（writable_paths + temp dirs）
- **受保护路径**：protected_paths 禁止写入（last-match-wins，覆盖 allow）
- **禁止读取**：deny_read_paths 同时禁止读写（保护 secrets）
- **设备文件**：/dev/null, /dev/ptmx, pseudo-tty
- **网络**：可选 outbound 开关
- **realpath** 防符号链接绕过

### Usage

```python
agent.register_seatbelt_sandbox_action(
    action_id="mac_sandbox",
    network=False,
    writable_paths=["/workspace"],
    protected_paths=["/workspace/.git"],
    deny_read_paths=["/home/user/.env"],
)