### PR TITLE
Prepare Agently 4.1.4.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img width="640" alt="Agently" src="https://github.com/user-attachments/assets/c645d031-c8b0-4dba-a515-9d7a4b0a6881" />
 
-# Agently 4.1.4.4 - AI Application Runtime Framework
+# Agently 4.1.4.5 - AI Application Runtime Framework
 
 > Build AI service backends with structured outputs, observable Actions, runtime Skills, MCP capabilities, process streams, and recoverable workflows.
 
@@ -32,11 +32,11 @@ Agently is for teams moving from "the model can do it once" to "the application 
 
 The main design question is simple: how do you keep model behavior useful while still giving application code stable contracts, observable execution, and restart-safe workflow boundaries?
 
-Agently 4.1.4.4 strengthens Pydantic field-constraint prompting and correction
-retries, adds recovery-aware TriggerFlow snapshot projection and bounded local
-snapshot retention, and moves default release validation away from local
-Ollama dependencies. The 4.1.4.2 runtime ownership boundaries and companion
-protocols remain unchanged. Read the
+Agently 4.1.4.5 adds opt-in lossless continuation for direct long-output
+executions and makes Agently-Stage the direct owner of TriggerFlow's
+process-local managed tasks. EventCenter, SignalNet, TriggerFlow, RuntimeEvent,
+and AgentExecution keep their semantic ownership. Read the
+[4.1.4.5 Release Notes](docs/en/development/release-notes-4.1.4.5.md),
 [4.1.4.4 Release Notes](docs/en/development/release-notes-4.1.4.4.md),
 [4.1.4.3 Release Notes](docs/en/development/release-notes-4.1.4.3.md), and
 [4.1.4 Release Notes](docs/en/development/release-notes-4.1.4.md) for the
@@ -48,7 +48,7 @@ Many AI frameworks are strong at exploration or at assembling broad integration 
 
 Agently is a good fit when you care about:
 
-- **AI services should be runtime executions, not prompt glue** - `AgentExecution` owns one run's prompt, strategy, Actions, Skill bindings, process stream, TaskContext evidence, and result views across direct, flat, and TaskBoard strategies. Read [4.1.4.4 Release Notes](docs/en/development/release-notes-4.1.4.4.md), [4.1.4 Release Notes](docs/en/development/release-notes-4.1.4.md), and [Agent Auto Orchestration examples](examples/agent_auto_orchestration/).
+- **AI services should be runtime executions, not prompt glue** - `AgentExecution` owns one run's prompt, strategy, Actions, Skill bindings, process stream, TaskContext evidence, and result views across direct, flat, and TaskBoard strategies. Read [4.1.4.5 Release Notes](docs/en/development/release-notes-4.1.4.5.md), [4.1.4 Release Notes](docs/en/development/release-notes-4.1.4.md), and [Agent Auto Orchestration examples](examples/agent_auto_orchestration/).
 - **Model switching should not rewrite business logic** - Agently normalizes provider setup, prompt slots, response parsing, action execution, and response reading into one request/runtime contract. Read [Model Setup](docs/en/start/model-setup.md), [Models Overview](docs/en/models/overview.md), and [Requests Overview](docs/en/requests/overview.md).
 - **Structured output should be a framework guarantee, not only a provider feature** - `.output(...)` schemas, required field extraction, parser feedback, retries, `ensure_keys`, `ensure_all_keys`, and validation handlers work together inside Agently. Read [Schema as Prompt](docs/en/requests/schema-as-prompt.md), [Output Control](docs/en/requests/output-control.md), and examples in [`examples/basic/`](examples/basic/).
 - **Streaming should expose structure before the final token** - `instant` mode lets consumers react to structured fields while the model is still streaming, which is useful for UI updates, SSE routes, and workflow signals. Read [Model Response](docs/en/requests/model-response.md), [FastAPI Service Exposure](docs/en/services/fastapi.md), and [`examples/fastapi/`](examples/fastapi/).
@@ -60,7 +60,7 @@ Agently is a good fit when you care about:
 - **Common model-app patterns should be composable** - router, To-Do/dependency execution, planning, reflection, evaluator/reviser, and multi-agent collaboration can be built from the same request/action/signal primitives. Read [Playbooks](docs/en/playbooks/overview.md), [TriggerFlow Model Integration](docs/en/triggerflow/model-integration.md), and [`examples/step_by_step/`](examples/step_by_step/).
 - **Services should keep clean project boundaries** - async APIs, FastAPI helpers, settings files, prompt files, DevTools observation, and companion coding-agent skills fit non-trivial projects. Read [Project Framework](docs/en/start/project-framework.md), [FastAPI Service Exposure](docs/en/services/fastapi.md), and [Observability](docs/en/observability/overview.md).
 
-Current framework version: `4.1.4.4`.
+Current framework version: `4.1.4.5`.
 
 Python: `>=3.10`.
 
@@ -208,7 +208,7 @@ Prompts are composed from named slots. That keeps application intent, constraint
 result = (
     agent
     .role("You are a concise release-note writer.")
-    .info({"version": "4.1.4.4", "audience": "framework users"})
+    .info({"version": "4.1.4.5", "audience": "framework users"})
     .instruct("Return only facts grounded in the input.")
     .input("Summarize this release line for an engineering changelog.")
     .output({
@@ -346,7 +346,7 @@ The older `tool_func` / `use_tools` / `use_mcp` / `use_sandbox` family remains a
 
 ### 5. Runtime Skills
 
-Skills are reusable task guidance packages. In 4.1.4.4, `SkillLibrary` owns
+Skills are reusable task guidance packages. In 4.1.4.5, `SkillLibrary` owns
 immutable installed revisions, AgentExecution owns selection and exact-revision
 binding, and TaskContext owns progressive disclosure. `agent.use_skills(...)`
 is the normal candidate-binding surface; `agent.require_skills(...)` binds a
@@ -517,7 +517,7 @@ pip install agently-devtools
 agently-devtools init my_project
 ```
 
-Agently 4.1.4.4 recommends `agently-devtools >=0.1.10,<0.2.0`.
+Agently 4.1.4.5 recommends `agently-devtools >=0.1.10,<0.2.0`.
 
 ## Architecture
 
@@ -692,7 +692,7 @@ Agently-Skills gives coding agents current Agently implementation guidance.
 - Repository: https://github.com/AgentEra/Agently-Skills
 - Current catalog generation: `v2`
 - Recommended bundle: `app`
-- Agently 4.1.4.4 compatibility: Skills authoring protocol `agently-skills.authoring.v2`
+- Agently 4.1.4.5 compatibility: Skills authoring protocol `agently-skills.authoring.v2`
 
 Use it when asking Codex, Claude Code, Cursor, or another coding agent to implement Agently patterns.
 
@@ -767,8 +767,8 @@ Use the async request APIs directly or wrap agents, requests, generators, Trigge
 
 ## Compatibility Notes
 
-- The current package version is `4.1.4.4`.
-- The current release manifest is `compatibility/releases/4.1.4.4.json`.
+- The current package version is `4.1.4.5`.
+- The current release manifest is `compatibility/releases/4.1.4.5.json`.
 - Development-line planning belongs in `compatibility/in-development.json`; do not treat planned future versions as released.
 - `AgentExecutionResult.get_data()` returns business data; callers that need status, TaskBoard, diagnostics, or other route/task internals use `get_full_data()`.
 - An explicitly captured `AgentExecution` represents one run. Create a fresh execution for the next request after it starts.

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,6 +1,6 @@
 <img width="640" alt="Agently" src="https://github.com/user-attachments/assets/c645d031-c8b0-4dba-a515-9d7a4b0a6881" />
 
-# Agently 4.1.4.4 - AI 应用运行时框架
+# Agently 4.1.4.5 - AI 应用运行时框架
 
 > 构建具备结构化输出、可观测 Actions、运行时 Skills、MCP 能力、过程流和可恢复工作流的 AI 服务后端。
 
@@ -32,9 +32,11 @@ Agently 面向的是正在从“模型偶尔能做对”走向“应用必须稳
 
 核心设计问题是：怎样保留模型能力，同时让应用代码拥有稳定契约、可观测执行和可重启的工作流边界？
 
-Agently 4.1.4.4 加强了 Pydantic 字段约束提示与修正重试，增加具备恢复语义的
-TriggerFlow 快照投影和有界本地快照保留，并让默认发布校验不再依赖本地
-Ollama。4.1.4.2 的运行时所有权边界和 companion protocol 保持不变。阅读
+Agently 4.1.4.5 增加 direct 长输出 execution 的可选无损续写，并让
+Agently-Stage 直接承接 TriggerFlow 的进程内 managed task 生命周期。
+EventCenter、SignalNet、TriggerFlow、RuntimeEvent 和 AgentExecution 的语义
+所有权保持不变。阅读
+[4.1.4.5 Release Notes](docs/cn/development/release-notes-4.1.4.5.md)、
 [4.1.4.4 Release Notes](docs/cn/development/release-notes-4.1.4.4.md)、
 [4.1.4.3 Release Notes](docs/cn/development/release-notes-4.1.4.3.md) 和
 [4.1.4 Release Notes](docs/cn/development/release-notes-4.1.4.md)
@@ -46,7 +48,7 @@ Ollama。4.1.4.2 的运行时所有权边界和 companion protocol 保持不变�
 
 当你关心这些问题时，Agently 会比较合适：
 
-- **AI 服务应该是运行时执行，不是 prompt glue** - `AgentExecution` 统一管理单次运行的 Prompt、strategy、Actions、Skill bindings、process stream、TaskContext evidence 和 result views，覆盖 direct、flat、TaskBoard strategy。阅读 [4.1.4.4 Release Notes](docs/cn/development/release-notes-4.1.4.4.md)、[4.1.4 Release Notes](docs/cn/development/release-notes-4.1.4.md) 和 [Agent Auto Orchestration 示例](examples/agent_auto_orchestration/)。
+- **AI 服务应该是运行时执行，不是 prompt glue** - `AgentExecution` 统一管理单次运行的 Prompt、strategy、Actions、Skill bindings、process stream、TaskContext evidence 和 result views，覆盖 direct、flat、TaskBoard strategy。阅读 [4.1.4.5 Release Notes](docs/cn/development/release-notes-4.1.4.5.md)、[4.1.4 Release Notes](docs/cn/development/release-notes-4.1.4.md) 和 [Agent Auto Orchestration 示例](examples/agent_auto_orchestration/)。
 - **换模型不应重写业务逻辑** - Agently 把 provider setup、Prompt 槽位、响应解析、Action 执行和响应读取归一到同一套 request/runtime contract。阅读 [模型设置](docs/cn/start/model-setup.md)、[模型概览](docs/cn/models/overview.md) 和 [Requests 概览](docs/cn/requests/overview.md)。
 - **结构化输出应是框架保障，不只是 provider 能力** - `.output(...)` schema、必填字段提取、parser feedback、重试、`ensure_keys`、`ensure_all_keys` 和 validation handlers 在 Agently 内部协同工作。阅读 [Schema as Prompt](docs/cn/requests/schema-as-prompt.md)、[输出控制](docs/cn/requests/output-control.md) 和 [`examples/basic/`](examples/basic/)。
 - **流式输出应在最后一个 token 前暴露结构** - `instant` mode 允许消费者在模型仍在流式输出时响应结构化字段，适合 UI 更新、SSE routes 和 workflow signals。阅读 [模型响应](docs/cn/requests/model-response.md)、[FastAPI 服务封装](docs/cn/services/fastapi.md) 和 [`examples/fastapi/`](examples/fastapi/)。
@@ -58,7 +60,7 @@ Ollama。4.1.4.2 的运行时所有权边界和 companion protocol 保持不变�
 - **常见模型应用模式应该可组合** - router、To-Do/dependency execution、planning、reflection、evaluator/reviser 和多 Agent 协作，都可以由同一套 request/action/signal primitives 组合出来。阅读 [Playbooks](docs/cn/playbooks/overview.md)、[TriggerFlow 模型集成](docs/cn/triggerflow/model-integration.md) 和 [`examples/step_by_step/`](examples/step_by_step/)。
 - **服务应保持清晰项目边界** - async API、FastAPI helpers、settings 文件、prompt 文件、DevTools 观测和 companion coding-agent skills 适合非一次性项目。阅读 [项目结构](docs/cn/start/project-framework.md)、[FastAPI 服务封装](docs/cn/services/fastapi.md) 和 [观测概览](docs/cn/observability/overview.md)。
 
-当前框架版本：`4.1.4.4`。
+当前框架版本：`4.1.4.5`。
 
 Python：`>=3.10`。
 
@@ -205,7 +207,7 @@ Prompt 由命名槽位组成。这样应用意图、约束、上下文和输出�
 result = (
     agent
     .role("你是简洁的 release note 作者。")
-    .info({"version": "4.1.4.4", "audience": "framework users"})
+    .info({"version": "4.1.4.5", "audience": "framework users"})
     .instruct("只基于输入事实作答。")
     .input("为工程 changelog 总结这个发布线。")
     .output({
@@ -340,7 +342,7 @@ raw = agent.action.read_action_artifact(
 
 ### 5. Runtime Skills
 
-Skills 是可复用的任务指导包。在 4.1.4.4 中，`SkillLibrary` 负责不可变的已安装
+Skills 是可复用的任务指导包。在 4.1.4.5 中，`SkillLibrary` 负责不可变的已安装
 revision，AgentExecution 负责选择和精确 revision binding，TaskContext 负责渐进
 disclosure。`agent.use_skills(...)` 是普通候选绑定入口；已知精确 revision 时使用
 `agent.require_skills(...)`。`Agently.skills_executor` 只保留安装、检查、context
@@ -502,7 +504,7 @@ pip install agently-devtools
 agently-devtools init my_project
 ```
 
-Agently 4.1.4.4 推荐 `agently-devtools >=0.1.10,<0.2.0`。
+Agently 4.1.4.5 推荐 `agently-devtools >=0.1.10,<0.2.0`。
 
 ## 架构
 
@@ -677,7 +679,7 @@ Agently-Skills 为 coding agent 提供当前 Agently 实现指导。
 - Repository: https://github.com/AgentEra/Agently-Skills
 - 当前 catalog generation: `v2`
 - 推荐 bundle: `app`
-- Agently 4.1.4.4 compatibility: Skills authoring protocol `agently-skills.authoring.v2`
+- Agently 4.1.4.5 compatibility: Skills authoring protocol `agently-skills.authoring.v2`
 
 当你让 Codex、Claude Code、Cursor 或其他 coding agent 实现 Agently 模式时，应使用它。
 
@@ -752,8 +754,8 @@ CrewAI 和 AutoGen 在以 agent 协作为核心的设计里很强。Agently 是�
 
 ## 兼容说明
 
-- 当前 package version 是 `4.1.4.4`。
-- 当前 release manifest 是 `compatibility/releases/4.1.4.4.json`。
+- 当前 package version 是 `4.1.4.5`。
+- 当前 release manifest 是 `compatibility/releases/4.1.4.5.json`。
 - 开发线计划写入 `compatibility/in-development.json`；不要把未来计划版本当作已发布版本。
 - `AgentExecutionResult.get_data()` 返回业务数据；需要 status、TaskBoard、diagnostics 或其他 route/task 内部信息时使用 `get_full_data()`。
 - 显式捕获的 `AgentExecution` 代表一次运行；启动后，下一次请求应创建新的 execution。

--- a/agently/compatibility.py
+++ b/agently/compatibility.py
@@ -5,8 +5,8 @@ from typing import Any
 
 
 CURRENT_COMPATIBILITY_SCHEMA_VERSION = 1
-CURRENT_FRAMEWORK_VERSION = "4.1.4.4"
-CURRENT_RELEASE_TRAIN = "2026-07-4.1.4.4"
+CURRENT_FRAMEWORK_VERSION = "4.1.4.5"
+CURRENT_RELEASE_TRAIN = "2026-07-4.1.4.5"
 
 DEVTOOLS_RUNTIME_PROTOCOL = "agently-devtools.observation-runtime.v1"
 SKILLS_AUTHORING_PROTOCOL = "agently-skills.authoring.v2"
@@ -15,13 +15,23 @@ DOCS_PUBLIC_SURFACE_PROTOCOL = "agently-docs.public-surface.v1"
 
 _CURRENT_RELEASE_MANIFEST: dict[str, Any] = {'schema_version': 1,
  'framework': 'agently',
- 'framework_version': '4.1.4.4',
- 'release_train': '2026-07-4.1.4.4',
- 'released_at': '2026-07-25',
- 'notes': 'Version-scoped companion compatibility manifest for Agently 4.1.4.4. This patch strengthens Pydantic output '
-          'constraints and correction retries, adds recovery-aware TriggerFlow snapshot projection and bounded local '
-          'snapshot retention, and moves default release validation away from local Ollama dependencies while '
-          'preserving existing owner boundaries and companion protocols.',
+ 'framework_version': '4.1.4.5',
+ 'release_train': '2026-07-4.1.4.5',
+ 'released_at': '2026-07-30',
+ 'notes': 'Version-scoped companion compatibility manifest for Agently 4.1.4.5. This patch adds opt-in lossless '
+          'continuation for direct long-output AgentExecution runs, makes Agently-Stage 0.3.5 the direct owner of '
+          'TriggerFlow process-local managed tasks, and keeps EventCenter, SignalNet, TriggerFlow, RuntimeEvent, and '
+          'AgentExecution semantic ownership unchanged.',
+ 'runtime_support': {'agently_stage': {'version_specifier': '>=0.3.5,<0.4.0',
+                                       'public_runtime_surface': False,
+                                       'task_mechanism_owners': ['TriggerFlowExecution'],
+                                       'stream_mechanism_owner': 'TriggerFlow execution stream',
+                                       'rejected_mechanism_replacements': ['EventCenter background task settlement',
+                                                                           'EventCenter and SignalNet event dispatch'],
+                                       'semantic_owners_unchanged': True,
+                                       'persistence_contract': 'Stage task inventory, Tunnel cursors, handles, and '
+                                                               'carrier state are process-local and are not '
+                                                               'serialized.'}},
  'companions': {'devtools': {'companion_package': 'agently-devtools',
                              'runtime_protocol': 'agently-devtools.observation-runtime.v1',
                              'event_naming': {'preferred_event_type': 'RuntimeEvent',
@@ -54,6 +64,17 @@ _CURRENT_RELEASE_MANIFEST: dict[str, Any] = {'schema_version': 1,
                                                                                                 'completed, failed, '
                                                                                                 'and cancelled '
                                                                                                 'outcomes.',
+                                                 'agent_execution_stream_completion_provenance': 'StreamingData and '
+                                                                                                 'AgentExecutionStreamData '
+                                                                                                 'may add optional '
+                                                                                                 'completion_source '
+                                                                                                 'values '
+                                                                                                 'observed_boundary, '
+                                                                                                 'final_reconciliation, '
+                                                                                                 'or synthetic_repair. '
+                                                                                                 'The field is '
+                                                                                                 'observation-only and '
+                                                                                                 'additive.',
                                                  'agent_execution_limits': ['max_seconds', 'max_no_progress_seconds'],
                                                  'provider_stream_idle_timeout': ['OpenAICompatible.stream_idle_timeout',
                                                                                   'OpenAIResponsesCompatible.stream_idle_timeout',
@@ -204,10 +225,10 @@ _CURRENT_RELEASE_MANIFEST: dict[str, Any] = {'schema_version': 1,
                                                                'put_checkpoint(...) writes are not automatically '
                                                                'pruned. Providers declaring supports_retention for '
                                                                'distributed recovery must expose prune_snapshots. This '
-                                                               'is an intentional 4.1.4.4 default behavior change and '
-                                                               'is separate from snapshot projection, RuntimeEvent '
-                                                               'compaction, business-state persistence, and full '
-                                                               'delete_snapshot(run_id) cleanup.',
+                                                               'is an intentional in-development default behavior '
+                                                               'change and is separate from snapshot projection, '
+                                                               'RuntimeEvent compaction, business-state persistence, '
+                                                               'and full delete_snapshot(run_id) cleanup.',
                                 'active_sub_flow_control': 'Running to_sub_flow children register serializable frames '
                                                            'before start. Explicit parent executions may signal or '
                                                            'cancel one live child by frame id; cancelled children skip '
@@ -294,10 +315,43 @@ _CURRENT_RELEASE_MANIFEST: dict[str, Any] = {'schema_version': 1,
                                                      'output requirements. Final Pydantic validation failures feed '
                                                      'bounded correction feedback into retries, and accepted typed '
                                                      'results remain reusable through object, data, and text readers.'},
-                   'agent_execution_request_scope': {'surface': ['AgentExecution', 'AgentExecutionResult'],
+                   'agent_execution_request_scope': {'surface': ['AgentExecution',
+                                                                 'AgentExecutionResult',
+                                                                 'AgentExecution.ensure_long_output'],
                                                      'contract': 'Each call owns an isolated AgentExecution draft. '
                                                                  'Completed executions are immutable run records; '
-                                                                 'prompt/config mutation after start fails fast.'},
+                                                                 'prompt/config mutation after start fails fast. '
+                                                                 'ensure_long_output(enabled=True) is a per-draft '
+                                                                 'direct-delivery policy: the first request keeps its '
+                                                                 'original contract, observed length termination '
+                                                                 'enters TriggerFlow continuation with private '
+                                                                 'TaskWorkspace staging, model-visible slot contracts '
+                                                                 'preserve nested containers from the original output '
+                                                                 'declaration, structured values pass an independent '
+                                                                 'local slot-schema validator before append-only '
+                                                                 'commit, explicitly observed empty lists and empty '
+                                                                 'text are retained without synthesizing missing '
+                                                                 'paths, and successful completion requires final '
+                                                                 'manifest replay plus the original validation '
+                                                                 'contracts. Continuation closes the '
+                                                                 'base_revision/base_digest/anchor control header '
+                                                                 'before business updates; a length terminal before '
+                                                                 'header closure is observable bounded no progress '
+                                                                 'that leaves the manifest unchanged, and three '
+                                                                 'consecutive no-progress continuations terminate. '
+                                                                 'Continuation finality is accepted only after '
+                                                                 'declared ensure paths have manifest facts; this '
+                                                                 "delivery barrier does not consume the caller's "
+                                                                 'final-validation retry allowance. A valid contiguous '
+                                                                 'prefix survives a rejected tail, and '
+                                                                 'model-repairable final validation failures retain '
+                                                                 'every accepted unit while using the bounded '
+                                                                 'validation-retry allowance for missing or additional '
+                                                                 'units. It currently supports plain text and JSON, '
+                                                                 'does not inherit Actions/tools into continuation '
+                                                                 'requests, fails closed on unknown terminals, invalid '
+                                                                 'assembly, or integrity mismatches, and cannot be '
+                                                                 'combined with an explicit AgentTask strategy.'},
                    'agent_execution_task_loop': {'surface': ['Agent.goal',
                                                              'Agent.goals',
                                                              'Agent.create_task',

--- a/compatibility/index.json
+++ b/compatibility/index.json
@@ -24,7 +24,8 @@
     "4.1.4.1": "compatibility/releases/4.1.4.1.json",
     "4.1.4.2": "compatibility/releases/4.1.4.2.json",
     "4.1.4.3": "compatibility/releases/4.1.4.3.json",
-    "4.1.4.4": "compatibility/releases/4.1.4.4.json"
+    "4.1.4.4": "compatibility/releases/4.1.4.4.json",
+    "4.1.4.5": "compatibility/releases/4.1.4.5.json"
   },
-  "latest_release": "4.1.4.4"
+  "latest_release": "4.1.4.5"
 }

--- a/compatibility/releases/4.1.4.5.json
+++ b/compatibility/releases/4.1.4.5.json
@@ -1,0 +1,245 @@
+{
+  "schema_version": 1,
+  "framework": "agently",
+  "framework_version": "4.1.4.5",
+  "release_train": "2026-07-4.1.4.5",
+  "released_at": "2026-07-30",
+  "notes": "Version-scoped companion compatibility manifest for Agently 4.1.4.5. This patch adds opt-in lossless continuation for direct long-output AgentExecution runs, makes Agently-Stage 0.3.5 the direct owner of TriggerFlow process-local managed tasks, and keeps EventCenter, SignalNet, TriggerFlow, RuntimeEvent, and AgentExecution semantic ownership unchanged.",
+  "runtime_support": {
+    "agently_stage": {
+      "version_specifier": ">=0.3.5,<0.4.0",
+      "public_runtime_surface": false,
+      "task_mechanism_owners": [
+        "TriggerFlowExecution"
+      ],
+      "stream_mechanism_owner": "TriggerFlow execution stream",
+      "rejected_mechanism_replacements": [
+        "EventCenter background task settlement",
+        "EventCenter and SignalNet event dispatch"
+      ],
+      "semantic_owners_unchanged": true,
+      "persistence_contract": "Stage task inventory, Tunnel cursors, handles, and carrier state are process-local and are not serialized."
+    }
+  },
+  "companions": {
+    "devtools": {
+      "companion_package": "agently-devtools",
+      "runtime_protocol": "agently-devtools.observation-runtime.v1",
+      "event_naming": {
+        "preferred_event_type": "RuntimeEvent",
+        "devtools_projection_type": "ObservationEvent",
+        "event_center_dispatch": "RuntimeEvent",
+        "compatibility_input_type": "ObservationEvent"
+      },
+      "runtime_control": {
+        "runtime_event_ownership": {
+          "official_event_producer": "core",
+          "plugin_contract": "plugins return observations/errors/decisions; core maps them to official RuntimeEvent records",
+          "builtin_direct_emitters_for_official_events": false,
+          "agent_execution_stream_owner": "agently.core.application.AgentExecution.AgentExecutionStream"
+        },
+        "record_store_contract": "RecordStore may persist canonical RuntimeEvent records when explicitly bound as runtime_event_store; TaskWorkspace is never an event store.",
+        "task_context_contract": "ContextPackage and ContextConsumption projections are bounded observation facts only and never drive route selection, verification, or task acceptance.",
+        "model_request_telemetry_contract": "Existing model RuntimeEvents may carry payload.model_request_telemetry observation facts; telemetry remains observation-only.",
+        "model_request_result_stream_status_contract": "ModelRequestResult reserves $status for completed, failed, and cancelled outcomes.",
+        "agent_execution_stream_completion_provenance": "StreamingData and AgentExecutionStreamData may add optional completion_source values observed_boundary, final_reconciliation, or synthetic_repair. The field is observation-only and additive.",
+        "agent_execution_limits": [
+          "max_seconds",
+          "max_no_progress_seconds"
+        ],
+        "provider_stream_idle_timeout": [
+          "OpenAICompatible.stream_idle_timeout",
+          "OpenAIResponsesCompatible.stream_idle_timeout",
+          "AnthropicCompatible.stream_idle_timeout"
+        ],
+        "response_materialization_idle_timeout": "response.materialization_idle_timeout",
+        "typed_stall_error": "RuntimeStageStallError",
+        "typed_provider_stall_stages": [
+          "response_first_event",
+          "response_stream",
+          "response_materialization"
+        ],
+        "action_runtime_stall_stages": [
+          "action_planning",
+          "tool_call_selection",
+          "action_execution",
+          "action_loop_close"
+        ],
+        "event_center_delivery_policy": {
+          "register_hook_parameter": "delivery_policy",
+          "hooker_attribute": "delivery_policy",
+          "fields": [
+            "mode",
+            "dispatch",
+            "emit_interval",
+            "max_items",
+            "high_frequency_only",
+            "max_summary_items"
+          ],
+          "background_reclaim": "idle_flush_and_explicit_flush",
+          "default_delivery": "raw",
+          "summary_marker": "meta.coalesced"
+        }
+      },
+      "recommended_version_specifier": ">=0.1.10,<0.2.0"
+    },
+    "skills": {
+      "repository": "Agently-Skills",
+      "authoring_protocol": "agently-skills.authoring.v2",
+      "authoring_format": "standard SKILL.md only",
+      "runtime_contract": {
+        "installed_truth_owner": "SkillLibrary immutable content-addressed revisions",
+        "selection_and_binding_owner": "AgentExecution structured semantic selection with host-issued keys and fail-closed validation",
+        "disclosure_owner": "TaskContext plus SkillContextSource plus consumer-bound ContextReader",
+        "compatibility_facade": "Agently.skills_executor supports local configure/install/list/inspect/read/context-pack/TaskDAG helpers only",
+        "execution_policy": "No Skills route, Skill-local strategy, stage engine, implicit script actionization, capability inference, or capability mounting; trusted exact-revision scripts require explicit host authorization and bind as ordinary Workspace-backed code_execution Actions",
+        "revision_binding_event": "skills.revisions.bound records exact revision availability without claiming activation",
+        "context_consumption_event": "skills.context.bound records concrete ModelRequest response-bound context consumption; availability alone is not consumption or Action evidence",
+        "remote_source_policy": "Registered SkillSourceProvider plugins materialize authorized local or Git sources to immutable local snapshots; SkillLibrary installs exact snapshots and records redacted provenance; remote compatibility installs default to untrusted and selected subpaths reject symlink escape"
+      },
+      "devtools_guidance_protocol": "agently-skills.devtools-guidance.v1",
+      "catalog_generation": "v2",
+      "recommended_bundle": "app",
+      "recommended_ref": "main",
+      "archived_catalog_generations": [
+        {
+          "generation": "v1",
+          "branch": "update/archive-legacy-v1-catalog",
+          "last_supported_framework_version": "4.1.1",
+          "status": "frozen"
+        }
+      ]
+    },
+    "blocks": {
+      "lifecycle_contract": "Blocks lowers validated ExecutionPlan data to TriggerFlow-backed ExecutionBlockGraph and maps results/evidence; it is not a Skill engine or persistence owner.",
+      "context_read_contract": "context_read consumes one caller-bound ContextReader and permits read/search/scoped_search only.",
+      "removed_block_kinds": [
+        "skill_activation",
+        "workspace_operation"
+      ],
+      "task_dag_contract": "TaskDAGExecutor validates submitted DAG data before direct TriggerFlow execution; compile_blocks and async_run_blocks are explicit opt-in carriers."
+    },
+    "docs": {
+      "repository": "docs",
+      "public_surface_protocol": "agently-docs.public-surface.v1"
+    },
+    "action_runtime": {
+      "task_workspace_contract": "TaskWorkspace Actions own bounded file read/search/write/edit/patch/export operations. A TaskWorkspace-bound shell resolves relative workdir values inside the injected root and consumes an already root-prefixed logical .agently/files/<execution-id> locator exactly once; paths outside the root fail closed.",
+      "record_store_contract": "Action persistence is explicit and does not follow from a TaskWorkspace binding.",
+      "code_execution_contract": "TaskWorkspace grant -> ordered provider selection/binding -> immutable CodeExecutionBundle materialization -> adapter-owned argv execution -> declared-output readback -> provider release -> grant close",
+      "code_execution_languages": [
+        "python>=3.10",
+        "nodejs>=18",
+        "go>=1.25",
+        "cpp20"
+      ],
+      "provider_selection_contract": "code_execution is the resource kind; provider candidates have stable provider_id values and optional candidate-local config; actual availability, normalized toolchain-version, TaskWorkspace access, safety, and typed isolation-axis probes select an eligible candidate; preferred capabilities are satisfied across the ordered set before an explicit fallback and selected facts remain in Action result metadata",
+      "provider_protocol_contract": "Directly registered ActionExecutor and ExecutionResourceProvider implementations satisfy runtime behavior protocols only. PluginManager-loaded implementations additionally satisfy the separate Agently plugin lifecycle contract at that boundary.",
+      "code_execution_output_contract": "expected_outputs contains at most 128 bounded normalized output/ paths; missing declared outputs fail the Action; retained stdout/stderr is bounded and timeout/cancellation stops the owned process or container",
+      "release_failure_contract": "provider release failures quarantine the handle and turn an otherwise successful Action into an error",
+      "unsafe_fallback_contract": "trusted_local is explicit unsafe host execution, requires allow_unsafe_local authorization and snapshot access, and cannot satisfy isolation=required",
+      "community_provider_contract": "PR #325 and #327 retain contributor ownership of concrete gVisor and Seatbelt implementations; the base branch provides only provider-neutral contracts, synthetic conformance fixtures, and migration guidance"
+    },
+    "triggerflow": {
+      "record_store_resource": "flow.create_execution(record_store=...); record_store=False opts out",
+      "task_workspace_contract": "TriggerFlow does not create or infer a TaskWorkspace.",
+      "durability_contract": "RecordStore or another explicit provider supplies snapshot, runtime-event, lease, and artifact-ref ports.",
+      "snapshot_projection_contract": "Execution snapshots use schema v2 and load full schema-v1 snapshots. Full values remain the default; set_snapshot_projection_policy(...) opts into idle-only digest projection for eligible terminal interrupt values and completed SignalNet resume metadata while pending recovery state remains complete. Canonical SHA-256 digest plus encoded size preserves duplicate/conflicting resume_request_id checks. This projection is separate from RuntimeEvent compaction and does not promise a whole-snapshot byte limit.",
+      "snapshot_retention_contract": "The built-in local RecordStore keeps the latest three execution snapshot versions per run_id by default; RecordStore(snapshot_retention={\"keep_last\": N|None}) configures or disables provider pruning, while execution.set_snapshot_retention_policy(...) is the persisted higher-precedence override. execution.async_prune_recovery_snapshots(keep_last=...) uses execution.run_id and preserves recovery; store.prune_snapshots(run_id, keep_last=...) is the explicit provider boundary. Generic put_checkpoint(...) writes are not automatically pruned. Providers declaring supports_retention for distributed recovery must expose prune_snapshots. This is an intentional in-development default behavior change and is separate from snapshot projection, RuntimeEvent compaction, business-state persistence, and full delete_snapshot(run_id) cleanup.",
+      "active_sub_flow_control": "Running to_sub_flow children register serializable frames before start. Explicit parent executions may signal or cancel one live child by frame id; cancelled children skip write-back and continuation. Live child handles are process-local, so active-frame snapshots fail closed on load while waiting interrupt frames remain resumable."
+    },
+    "task_context": {
+      "owner": "TaskContext",
+      "reader": "ContextReader",
+      "package": "ContextPackage",
+      "derived_index_owner": "TaskContext internal ContextIndex",
+      "source_protocol": "ContextSource async_enumerate_descriptors plus async_read_exact, with optional ContextSourceScopedRead for deterministic bounded location only after one canonical ref is selected; sources own canonical truth while TaskContext owns disposable derived partitions",
+      "source_kinds": "open adapter vocabulary",
+      "source_adapters": [
+        "SkillContextSource",
+        "TaskWorkspaceContextSource",
+        "RecordStoreContextSource",
+        "AgentlyMemoryContextSource"
+      ],
+      "selection_contract": "ContextIndex owns structural, lexical, and optional hybrid candidate retrieval; ContextReader owns consumer-local offsets, exact or selected-ref scoped readback, budgets, and optional ModelRequest structured selection with host-issued keys. An exact non-wildcard path with one authorized candidate is host-selected without another semantic request. Required and explicit blocks cannot be silently dropped; unknown source kinds fail before enumeration.",
+      "model_hot_projection_contract": "ContextPackage retains full omission and diagnostic facts for audit. AgentTask joins every scoped body one-to-one against host-side execution-block, ContextBlock, source-revision, binding, and canonical-ref identity before disclosure; missing or ambiguous joins exclude the body with diagnostics. Model-hot projections expose one host-issued reference_id plus task-relevant source labels, omit opaque host identities, bound repetitive optional omission details with aggregate reason counts, and do not duplicate the same body in the evidence ledger. A scoped plan may reserve at most 64 model-visible results per execution batch across query-group max_results; an otherwise valid larger TaskBoard plan is deterministically split into bounded Context-owned batches plus a dependent continuation without changing source kinds or silently truncating, while an individually over-capacity or invalid group fails closed for structured replanning."
+    },
+    "task_workspace": {
+      "surface": [
+        "TaskWorkspace",
+        "TaskWorkspace.register_file_io_handler",
+        "Agent.use_task_workspace",
+        "Agent.enable_task_workspace_file_actions"
+      ],
+      "default_root": "<entry-directory>/.agently/task_workspaces/<agent-id>",
+      "ownership": "Task files, path policy, physical readback, digest, file refs, scoped execution grants, immutable bundle materialization, and declared-output collection",
+      "terminal_artifact_contract": "Required AgentTask deliverables remain digest-pinned staged candidates through verifier acceptance, then use atomic target promotion and complete post-promotion readback; failure blocks delivery without overwriting the prior accepted target. A sufficient completed control result with a draftable manifest but no body enters the dedicated artifact-draft stage with the same bounded canonical evidence ledger; framework-owned materialization is not semantic remaining work."
+    },
+    "record_store": {
+      "surface": [
+        "RecordStore",
+        "RecordStoreRegistry",
+        "Agent.use_record_store",
+        "TriggerFlow.create_execution(record_store=...)"
+      ],
+      "local_state": "<root>/.agently/records/records.db",
+      "ownership": "Records, indexes, links, checkpoints, snapshots, snapshot version retention and cleanup, runtime events, leases, and memory persistence"
+    },
+    "session_memory": {
+      "storage_owner": "RecordStore",
+      "strategy_owner": "SessionMemory plugin",
+      "recall_owner": "TaskContext via AgentlyMemoryContextSource",
+      "task_file_dependency": false
+    }
+  },
+  "request_input": {
+    "structured_output": {
+      "surface": [
+        "ModelRequest.output",
+        "AgentExecution.output",
+        "ModelRequestResult.get_data_object"
+      ],
+      "contract": "Pydantic v2 BaseModel classes are recursively projected into prompt schemas; required, nullability, length, count, numeric range, pattern, enum, and format constraints are rendered as output requirements. Final Pydantic validation failures feed bounded correction feedback into retries, and accepted typed results remain reusable through object, data, and text readers."
+    },
+    "agent_execution_request_scope": {
+      "surface": [
+        "AgentExecution",
+        "AgentExecutionResult",
+        "AgentExecution.ensure_long_output"
+      ],
+      "contract": "Each call owns an isolated AgentExecution draft. Completed executions are immutable run records; prompt/config mutation after start fails fast. ensure_long_output(enabled=True) is a per-draft direct-delivery policy: the first request keeps its original contract, observed length termination enters TriggerFlow continuation with private TaskWorkspace staging, model-visible slot contracts preserve nested containers from the original output declaration, structured values pass an independent local slot-schema validator before append-only commit, explicitly observed empty lists and empty text are retained without synthesizing missing paths, and successful completion requires final manifest replay plus the original validation contracts. Continuation closes the base_revision/base_digest/anchor control header before business updates; a length terminal before header closure is observable bounded no progress that leaves the manifest unchanged, and three consecutive no-progress continuations terminate. Continuation finality is accepted only after declared ensure paths have manifest facts; this delivery barrier does not consume the caller's final-validation retry allowance. A valid contiguous prefix survives a rejected tail, and model-repairable final validation failures retain every accepted unit while using the bounded validation-retry allowance for missing or additional units. It currently supports plain text and JSON, does not inherit Actions/tools into continuation requests, fails closed on unknown terminals, invalid assembly, or integrity mismatches, and cannot be combined with an explicit AgentTask strategy."
+    },
+    "agent_execution_task_loop": {
+      "surface": [
+        "Agent.goal",
+        "Agent.goals",
+        "Agent.create_task",
+        "Agent.resume",
+        "Agent.async_resume",
+        "AgentExecution.strategy(\"auto\"|\"direct\"|\"flat\"|\"taskboard\")"
+      ],
+      "context_contract": "AgentExecution and AgentTask share one TaskContext and one execution-scoped TaskWorkspace view.",
+      "durability_contract": "Process state stays in memory/logs by default; record_store_recovery is opt-in.",
+      "evidence_replan_contract": "A material-evidence replan_segment without an unresolved mounted capability first uses a dedicated ModelRequest to choose bounded semantic queries from host-offered TaskContext source kinds, then creates one or more Context-owned evidence-reacquisition cards before a dependent artifact-repair card. The host requires evidence_use to bind the exact new body-bearing owner/locator/content_version/range identities added to EvidenceLedger, excludes final-artifact self-readback from progress, and permits another repair only when a newly acquired reference is consumed by the original failed criterion or stable exact material-claim subject.",
+      "taskboard_live_evidence_contract": "Dependency readback evidence is canonicalized before prompt construction; prompt projection, host binding validation, acceptance indexing, result persistence, and a dedicated manifest-to-body artifact draft share one live ledger identity domain. A control result with sufficient=false cannot become completed through next_board_action=finalize; a sufficient completed draftable manifest may hand framework-owned materialization to the artifact-draft stage without being blocked by semantic remaining_work."
+    },
+    "skills": {
+      "surface": [
+        "AgentExecution.use_skills",
+        "AgentExecution.require_skills",
+        "AgentExecution.use_skills_packs",
+        "AgentExecution.async_prepare_task_context",
+        "AgentExecution.async_read_task_context",
+        "Agent.run_skills_task",
+        "Agently.skills_executor"
+      ],
+      "contract": "Direct AgentExecution binding is canonical; async_read_task_context binds consumer/phase and accepts an optional string or ContextReadIntent override; run_skills_task is a result-shaped adapter and Agently.skills_executor is management/context compatibility only."
+    }
+  },
+  "public_typing": {
+    "status": "required",
+    "surface": "compatibility/public-typing-allowlist.json",
+    "contract": "New public methods default to typed parameters and returns; Any boundaries require explicit allowlist reasons.",
+    "compatibility_policy": "The allowlist records deliberate Any boundaries; it is not a public-method allowlist."
+  }
+}

--- a/docs/cn/development/README.md
+++ b/docs/cn/development/README.md
@@ -5,21 +5,22 @@
 1. [Coding Agents](coding-agents.md)：用 Agently-Skills companion repo 帮 Codex、Claude Code、Cursor 等工具获得当前 Agently 指引。
 2. [Skills Compatibility](skills-executor.md)：框架内通过 Agent API、plan、Actions 和 legacy SkillsExecutor facade 消费 runtime skills。
 3. [Code Execution Provider 迁移](code-execution-provider-migration.md)：Workspace-backed provider 契约和外部隔离 provider 的贡献者自有迁移目标。
-4. [Agently 4.1.4.4 Release Notes](release-notes-4.1.4.4.md)：更完整的 Pydantic 约束、具备恢复语义的 TriggerFlow 快照，以及线上模型优先的发布校验。
-5. [Agently 4.1.4.3 Release Notes](release-notes-4.1.4.3.md)：直接与嵌套 Pydantic v2 输出模型兼容性修复。
-6. [Agently 4.1.4.2 Release Notes](release-notes-4.1.4.2.md)：TaskContext、TaskWorkspace、RecordStore 与 SkillLibrary 所有权收敛的破坏式更新。
-7. [Agently 4.1.4.1 Release Notes](release-notes-4.1.4.1.md)：AgentExecutionResult 业务数据和完整数据 reader 兼容性。
-8. [Agently 4.1.4 Development Notes](release-notes-4.1.4.md)：TaskBoard 增量验收和 verifier cache 优化。
-9. [Agently 4.1.3.9 Release Notes](release-notes-4.1.3.9.md)：Workspace retrieval、SessionMemory、AgentTask scoped retrieval、向量索引接缝和公开 typing 加固。
-10. [Agently 4.1.3.8 Release Notes](release-notes-4.1.3.8.md)：任务执行策略优化、TaskBoard 策略选择、ACP fallback 能力、输出控制兜底、观测兼容和公开类型元数据。
-11. [Agently 4.1.3.7 Release Notes](release-notes-4.1.3.7.md)：AgentExecution-backed AgentTaskLoop 加固、goal/effort 配置、Skills context packs 和 release-blocker runtime 修复。
-12. [Agently 4.1.3.6 Release Notes](release-notes-4.1.3.6.md)：AgentExecution ownership、Result-first 消费、stream-end hardening 和 bounded task-loop slice。
-13. [Agently 4.1.3.5 Release Notes](release-notes-4.1.3.5.md)：4.1.3.5 的历史 release note，记录 settings-owned 输出默认值和 prompt 隔离工作；当前合同已由 AgentExecution draft 模型承接。
-14. [Agently 4.1.3.4 Release Notes](release-notes-4.1.3.4.md)：结构化输出解析加固、请求重试、运行时能力策略和 AgentTaskLoop first public slice。
-15. [Agently 4.1.3.3 Release Notes](release-notes-4.1.3.3.md)：typed settings/options、model profiles、API key pool failover、runtime handler ownership、core package refactors 和 image input。
-16. [Agently 4.1.3.2 Release Notes](release-notes-4.1.3.2.md)：bounded AgentExecution task steps、Workspace-backed step context、runtime stall control 和 EventCenter RuntimeEvent delivery。
-17. [Agently 4.1.3.1 Release Notes](release-notes-4.1.3.1.md)：Workspace foundation、Recall skeleton 和显式多轮任务信息管理。
-18. [Agently 4.1.3 Release Notes](release-notes-4.1.3.md)：4.1.3 最终运行时目标、推荐代码形态和业务价值。
-19. [Release Workflows](release-workflows.md)：当前主仓库的 docs、安装包和 PyPI 发布自动化。
+4. [Agently 4.1.4.5 Release Notes](release-notes-4.1.4.5.md)：可选长输出续写，以及由 Stage 直接支撑的 TriggerFlow task 生命周期。
+5. [Agently 4.1.4.4 Release Notes](release-notes-4.1.4.4.md)：更完整的 Pydantic 约束、具备恢复语义的 TriggerFlow 快照，以及线上模型优先的发布校验。
+6. [Agently 4.1.4.3 Release Notes](release-notes-4.1.4.3.md)：直接与嵌套 Pydantic v2 输出模型兼容性修复。
+7. [Agently 4.1.4.2 Release Notes](release-notes-4.1.4.2.md)：TaskContext、TaskWorkspace、RecordStore 与 SkillLibrary 所有权收敛的破坏式更新。
+8. [Agently 4.1.4.1 Release Notes](release-notes-4.1.4.1.md)：AgentExecutionResult 业务数据和完整数据 reader 兼容性。
+9. [Agently 4.1.4 Development Notes](release-notes-4.1.4.md)：TaskBoard 增量验收和 verifier cache 优化。
+10. [Agently 4.1.3.9 Release Notes](release-notes-4.1.3.9.md)：Workspace retrieval、SessionMemory、AgentTask scoped retrieval、向量索引接缝和公开 typing 加固。
+11. [Agently 4.1.3.8 Release Notes](release-notes-4.1.3.8.md)：任务执行策略优化、TaskBoard 策略选择、ACP fallback 能力、输出控制兜底、观测兼容和公开类型元数据。
+12. [Agently 4.1.3.7 Release Notes](release-notes-4.1.3.7.md)：AgentExecution-backed AgentTaskLoop 加固、goal/effort 配置、Skills context packs 和 release-blocker runtime 修复。
+13. [Agently 4.1.3.6 Release Notes](release-notes-4.1.3.6.md)：AgentExecution ownership、Result-first 消费、stream-end hardening 和 bounded task-loop slice。
+14. [Agently 4.1.3.5 Release Notes](release-notes-4.1.3.5.md)：4.1.3.5 的历史 release note，记录 settings-owned 输出默认值和 prompt 隔离工作；当前合同已由 AgentExecution draft 模型承接。
+15. [Agently 4.1.3.4 Release Notes](release-notes-4.1.3.4.md)：结构化输出解析加固、请求重试、运行时能力策略和 AgentTaskLoop first public slice。
+16. [Agently 4.1.3.3 Release Notes](release-notes-4.1.3.3.md)：typed settings/options、model profiles、API key pool failover、runtime handler ownership、core package refactors 和 image input。
+17. [Agently 4.1.3.2 Release Notes](release-notes-4.1.3.2.md)：bounded AgentExecution task steps、Workspace-backed step context、runtime stall control 和 EventCenter RuntimeEvent delivery。
+18. [Agently 4.1.3.1 Release Notes](release-notes-4.1.3.1.md)：Workspace foundation、Recall skeleton 和显式多轮任务信息管理。
+19. [Agently 4.1.3 Release Notes](release-notes-4.1.3.md)：4.1.3 最终运行时目标、推荐代码形态和业务价值。
+20. [Release Workflows](release-workflows.md)：当前主仓库的 docs、安装包和 PyPI 发布自动化。
 
 DevTools 归 [Observability](../observability/)，因为它消费 observation event。Action、MCP 和服务 API 放在各自文件夹里。

--- a/docs/cn/development/release-notes-4.1.4.5.md
+++ b/docs/cn/development/release-notes-4.1.4.5.md
@@ -1,0 +1,93 @@
+---
+title: Agently 4.1.4.5 发布说明
+description: 可选长输出续写，以及由 Stage 直接支撑的 TriggerFlow task 生命周期。
+keywords: Agently, 4.1.4.5, 长输出, TriggerFlow, Agently-Stage, settlement
+---
+
+# Agently 4.1.4.5 发布说明
+
+Agently 4.1.4.5 加强了两个运行时边界，但没有改变语义 owner：
+
+- 当 direct `ModelRequest` 以可观测的 length 或 incomplete terminal 结束时，
+  `AgentExecution` 可以显式启用无损续写；
+- `TriggerFlowExecution` 直接使用 Agently-Stage 管理进程内 task，不再复制第二套
+  task scope。
+
+## 可选长输出续写
+
+当业务结果必须跨越 provider 单次响应窗口时，在尚未启动的 direct
+`AgentExecution` 上调用 `.ensure_long_output()`：
+
+```python
+result = (
+    agent
+    .input({"topic": "runtime ownership"})
+    .instruct("输出完整技术报告。")
+    .ensure_long_output()
+    .get_result()
+)
+```
+
+第一次请求保留原有 Prompt 和输出契约。只有 provider/parser terminal 明确报告
+length 或 incomplete，才会进入续写。已接受的文本或结构化单元采用 append-only
+提交，通过 `TaskWorkspace` 保存并完整读回，最终仍需通过原始输出契约验证。
+
+该策略默认关闭，支持纯文本和已声明的 JSON 输出契约，不能与显式 AgentTask
+strategy 同时使用。普通成功响应仍保持单次请求。
+
+参见[输出控制](../requests/output-control.md)和
+[`examples/basic/ensure_long_output.py`](../../../examples/basic/ensure_long_output.py)。
+
+## Stage 支撑的 TriggerFlow task ownership
+
+Agently 现在依赖 `agently-stage >=0.3.5,<0.4.0`。
+
+每个 `TriggerFlowExecution` 直接持有一个真实 Stage：
+
+- execution 自己创建的 caller-loop task 通过 `Stage.create_task(...)` 进入；
+- 只有接管前已经存在的 task 才通过 `Stage.adopt(...)` 进入；
+- Stage 是唯一的实时 task/origin inventory 和 settlement owner；
+- TriggerFlow 继续负责工作流失败策略、单一 close deadline、RuntimeEvent
+  投影与 close snapshot。
+
+旧的私有 `StageManagedTaskScope` adapter 已删除。这不意味着 Agently 对外暴露
+Stage lifecycle：EventCenter、SignalNet、TriggerFlow、RuntimeEvent 和
+AgentExecution 继续拥有各自语义。
+
+隐藏 runtime-stream execution 会在消费结束后显式 close 和 settlement，避免
+idle monitor 在 caller loop 退出后残留。EventCenter 继续使用原生后台任务机制，
+因为实验中替换该热路径的可测开销不值得接受。
+
+## 同步/异步兼容
+
+Agently 内部的调用形态桥接使用 Agently-Stage `StageCallBridge`。
+`FunctionShifter` 仍可导入，但只作为 deprecated 兼容 facade，并委托给同一个
+bridge；新的框架代码不应让它负责 task 生命周期。
+
+## 性能特征
+
+Stage-native TriggerFlow 与旧私有 adapter 进行了两轮反向顺序本地 A/B，每个
+variant 共记录 18 个样本：
+
+| 工作负载 | Candidate 变化 |
+|---|---:|
+| Managed task 创建与 settlement | +4.74%（约 +0.61 µs/task） |
+| 取消 settlement | -3.08% |
+| 有限 TriggerFlow execution | -1.34% |
+| TriggerFlow event fan-out | +0.29% |
+| Peak traced task memory | 0.00% |
+
+实验没有产生 pending-task、未消费异常或生命周期警告。这些数据证明的是本地开销
+可控，并不表示 Stage 会让 provider-bound 模型请求变快。
+
+## 兼容性
+
+- Python：`>=3.10`
+- Agently-Stage：`>=0.3.5,<0.4.0`
+- 推荐 Agently DevTools：`>=0.1.10,<0.2.0`
+- Skills authoring protocol：`agently-skills.authoring.v2`
+- DevTools observation protocol：`agently-devtools.observation-runtime.v1`
+
+4.1.4.4 的 ModelRequest、TriggerFlow snapshot、RecordStore retention 和
+companion protocol 契约继续受支持。
+

--- a/docs/cn/index.md
+++ b/docs/cn/index.md
@@ -49,6 +49,7 @@ Agently 是一个面向 AI 应用开发的框架，服务于团队从模型原�
    - [Event Center](observability/event-center.md)
    - [DevTools](observability/devtools.md)
    - [Coding Agents](development/coding-agents.md)
+   - [Agently 4.1.4.5 Release Notes](development/release-notes-4.1.4.5.md)
    - [Agently 4.1.4.4 Release Notes](development/release-notes-4.1.4.4.md)
    - [Agently 4.1.4.3 Release Notes](development/release-notes-4.1.4.3.md)
    - [Agently 4.1.4.2 Release Notes](development/release-notes-4.1.4.2.md)

--- a/docs/en/development/README.md
+++ b/docs/en/development/README.md
@@ -5,21 +5,22 @@ Read in this order:
 1. [Coding Agents](coding-agents.md): using the Agently-Skills companion repo with Codex, Claude Code, Cursor, and similar tools.
 2. [Skills Compatibility](skills-executor.md): framework-side Skill consumption through Agent APIs, plans, Actions, and the legacy SkillsExecutor facade.
 3. [Code Execution Provider Migration](code-execution-provider-migration.md): Workspace-backed provider contract and contributor-owned migration targets for external isolation providers.
-4. [Agently 4.1.4.4 Release Notes](release-notes-4.1.4.4.md): stronger Pydantic constraints, recovery-aware TriggerFlow snapshots, and online-model-first release validation.
-5. [Agently 4.1.4.3 Release Notes](release-notes-4.1.4.3.md): direct and nested Pydantic v2 output-model compatibility.
-6. [Agently 4.1.4.2 Release Notes](release-notes-4.1.4.2.md): breaking TaskContext, TaskWorkspace, RecordStore, and SkillLibrary ownership convergence.
-7. [Agently 4.1.4.1 Release Notes](release-notes-4.1.4.1.md): AgentExecutionResult business-data and full-data reader compatibility.
-8. [Agently 4.1.4 Development Notes](release-notes-4.1.4.md): TaskBoard incremental acceptance and verifier-cache optimization.
-9. [Agently 4.1.3.9 Release Notes](release-notes-4.1.3.9.md): Workspace retrieval, SessionMemory, AgentTask scoped retrieval, vector-index seams, and public typing hardening.
-10. [Agently 4.1.3.8 Release Notes](release-notes-4.1.3.8.md): task execution strategy optimization, TaskBoard policy selection, ACP fallback capability, output-control fallback, observation compatibility, and public typing metadata.
-11. [Agently 4.1.3.7 Release Notes](release-notes-4.1.3.7.md): AgentExecution-backed AgentTaskLoop hardening, goal/effort configuration, Skills context packs, and release-blocker runtime fixes.
-12. [Agently 4.1.3.6 Release Notes](release-notes-4.1.3.6.md): AgentExecution ownership, Result-first consumption, stream-end hardening, and bounded task-loop slice.
-13. [Agently 4.1.3.5 Release Notes](release-notes-4.1.3.5.md): historical 4.1.3.5 notes for settings-owned output defaults and prompt isolation work superseded by the current AgentExecution draft model.
-14. [Agently 4.1.3.4 Release Notes](release-notes-4.1.3.4.md): structured output parsing hardening, request retry, runtime capability policy, and AgentTaskLoop first public slice.
-15. [Agently 4.1.3.3 Release Notes](release-notes-4.1.3.3.md): typed settings/options, model profiles, API key pool failover, runtime handler ownership, core package refactors, and image input.
-16. [Agently 4.1.3.2 Release Notes](release-notes-4.1.3.2.md): bounded AgentExecution task steps, Workspace-backed step context, runtime stall control, and EventCenter RuntimeEvent delivery.
-17. [Agently 4.1.3.1 Release Notes](release-notes-4.1.3.1.md): Workspace foundation, Recall skeleton, and explicit multi-turn task information management.
-18. [Agently 4.1.3 Release Notes](release-notes-4.1.3.md): final 4.1.3 runtime goals, user-facing code shape, and business value.
-19. [Release Workflows](release-workflows.md): current repository automation for docs, installers, and PyPI publishing.
+4. [Agently 4.1.4.5 Release Notes](release-notes-4.1.4.5.md): opt-in long-output continuation and Stage-backed TriggerFlow task lifecycle ownership.
+5. [Agently 4.1.4.4 Release Notes](release-notes-4.1.4.4.md): stronger Pydantic constraints, recovery-aware TriggerFlow snapshots, and online-model-first release validation.
+6. [Agently 4.1.4.3 Release Notes](release-notes-4.1.4.3.md): direct and nested Pydantic v2 output-model compatibility.
+7. [Agently 4.1.4.2 Release Notes](release-notes-4.1.4.2.md): breaking TaskContext, TaskWorkspace, RecordStore, and SkillLibrary ownership convergence.
+8. [Agently 4.1.4.1 Release Notes](release-notes-4.1.4.1.md): AgentExecutionResult business-data and full-data reader compatibility.
+9. [Agently 4.1.4 Development Notes](release-notes-4.1.4.md): TaskBoard incremental acceptance and verifier-cache optimization.
+10. [Agently 4.1.3.9 Release Notes](release-notes-4.1.3.9.md): Workspace retrieval, SessionMemory, AgentTask scoped retrieval, vector-index seams, and public typing hardening.
+11. [Agently 4.1.3.8 Release Notes](release-notes-4.1.3.8.md): task execution strategy optimization, TaskBoard policy selection, ACP fallback capability, output-control fallback, observation compatibility, and public typing metadata.
+12. [Agently 4.1.3.7 Release Notes](release-notes-4.1.3.7.md): AgentExecution-backed AgentTaskLoop hardening, goal/effort configuration, Skills context packs, and release-blocker runtime fixes.
+13. [Agently 4.1.3.6 Release Notes](release-notes-4.1.3.6.md): AgentExecution ownership, Result-first consumption, stream-end hardening, and bounded task-loop slice.
+14. [Agently 4.1.3.5 Release Notes](release-notes-4.1.3.5.md): historical 4.1.3.5 notes for settings-owned output defaults and prompt isolation work superseded by the current AgentExecution draft model.
+15. [Agently 4.1.3.4 Release Notes](release-notes-4.1.3.4.md): structured output parsing hardening, request retry, runtime capability policy, and AgentTaskLoop first public slice.
+16. [Agently 4.1.3.3 Release Notes](release-notes-4.1.3.3.md): typed settings/options, model profiles, API key pool failover, runtime handler ownership, core package refactors, and image input.
+17. [Agently 4.1.3.2 Release Notes](release-notes-4.1.3.2.md): bounded AgentExecution task steps, Workspace-backed step context, runtime stall control, and EventCenter RuntimeEvent delivery.
+18. [Agently 4.1.3.1 Release Notes](release-notes-4.1.3.1.md): Workspace foundation, Recall skeleton, and explicit multi-turn task information management.
+19. [Agently 4.1.3 Release Notes](release-notes-4.1.3.md): final 4.1.3 runtime goals, user-facing code shape, and business value.
+20. [Release Workflows](release-workflows.md): current repository automation for docs, installers, and PyPI publishing.
 
 DevTools belongs to [Observability](../observability/) because it consumes observation events. Action, MCP, and service APIs live in their own folders.

--- a/docs/en/development/release-notes-4.1.4.5.md
+++ b/docs/en/development/release-notes-4.1.4.5.md
@@ -1,0 +1,101 @@
+---
+title: Agently 4.1.4.5 Release Notes
+description: Opt-in long-output continuation and Stage-backed TriggerFlow task lifecycle ownership.
+keywords: Agently, 4.1.4.5, long output, TriggerFlow, Agently-Stage, settlement
+---
+
+# Agently 4.1.4.5 Release Notes
+
+Agently 4.1.4.5 strengthens two runtime boundaries without changing their
+semantic owners:
+
+- `AgentExecution` can opt into lossless continuation when a direct
+  `ModelRequest` ends with an observed length or incomplete terminal;
+- `TriggerFlowExecution` now uses Agently-Stage as the direct owner of its
+  process-local managed tasks instead of reproducing a second task scope.
+
+## Opt-in long-output continuation
+
+Call `.ensure_long_output()` on an unstarted direct `AgentExecution` when the
+business result must survive a provider response-window boundary:
+
+```python
+result = (
+    agent
+    .input({"topic": "runtime ownership"})
+    .instruct("Write the complete technical report.")
+    .ensure_long_output()
+    .get_result()
+)
+```
+
+The first request keeps its original prompt and output contract. Continuation
+starts only after an observed provider/parser terminal explicitly reports
+length or incomplete output. Accepted text or structured units are committed
+append-only, stored through `TaskWorkspace`, read back, and validated against
+the original output contract before delivery.
+
+This policy is disabled by default. It supports plain text and declared JSON
+output contracts and cannot be combined with an explicit AgentTask strategy.
+Ordinary successful responses remain single-request executions.
+
+See [Output Control](../requests/output-control.md) and
+[`examples/basic/ensure_long_output.py`](../../../examples/basic/ensure_long_output.py).
+
+## Stage-backed TriggerFlow task ownership
+
+Agently now requires `agently-stage >=0.3.5,<0.4.0`.
+
+Each `TriggerFlowExecution` directly owns one real Stage:
+
+- execution-created caller-loop tasks enter through `Stage.create_task(...)`;
+- genuinely pre-existing tasks enter through `Stage.adopt(...)`;
+- Stage is the single live task/origin inventory and settlement owner;
+- TriggerFlow retains workflow failure policy, one close deadline,
+  RuntimeEvent projection, and close snapshots.
+
+The former private `StageManagedTaskScope` adapter has been deleted. This is
+not a public Stage API exposure through Agently: EventCenter, SignalNet,
+TriggerFlow, RuntimeEvent, and AgentExecution keep their existing semantic
+ownership.
+
+Hidden runtime-stream executions now close and settle explicitly after stream
+consumption, preventing an idle monitor from surviving the caller loop.
+EventCenter keeps its native background-task mechanism because replacing that
+hot path did not justify its measured overhead.
+
+## Sync/async compatibility
+
+Agently's internal call-shape bridges use Agently-Stage `StageCallBridge`.
+`FunctionShifter` remains importable as a deprecated compatibility facade and
+delegates to the same bridge; new framework code should not use it as a task
+lifecycle owner.
+
+## Performance characterization
+
+The Stage-native TriggerFlow candidate was compared with the previous private
+adapter in two reverse-order local runs, with 18 recorded samples per variant:
+
+| Workload | Candidate delta |
+|---|---:|
+| Managed task create and settlement | +4.74% (about +0.61 µs/task) |
+| Cancellation settlement | -3.08% |
+| Finite TriggerFlow execution | -1.34% |
+| TriggerFlow event fan-out | +0.29% |
+| Peak traced task memory | 0.00% |
+
+No run emitted a pending-task, unconsumed-exception, or lifecycle warning.
+These numbers demonstrate bounded local overhead; they do not claim that Stage
+makes provider-bound model requests faster.
+
+## Compatibility
+
+- Python: `>=3.10`
+- Agently-Stage: `>=0.3.5,<0.4.0`
+- Recommended Agently DevTools: `>=0.1.10,<0.2.0`
+- Skills authoring protocol: `agently-skills.authoring.v2`
+- DevTools observation protocol: `agently-devtools.observation-runtime.v1`
+
+The 4.1.4.4 ModelRequest, TriggerFlow snapshot, RecordStore retention, and
+companion protocol contracts remain supported.
+

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -49,6 +49,7 @@ This handbook is organized as a learning path. If you have not run a single requ
    - [Event Center](observability/event-center.md)
    - [DevTools](observability/devtools.md)
    - [Coding Agents](development/coding-agents.md)
+   - [Agently 4.1.4.5 Release Notes](development/release-notes-4.1.4.5.md)
    - [Agently 4.1.4.4 Release Notes](development/release-notes-4.1.4.4.md)
    - [Agently 4.1.4.3 Release Notes](development/release-notes-4.1.4.3.md)
    - [Agently 4.1.4.2 Release Notes](development/release-notes-4.1.4.2.md)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "agently-stage"
-version = "0.3.4"
+version = "0.3.5"
 description = "Agently Stage - Efficient Convenient Asynchronous and Multithreaded Programming"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "agently_stage-0.3.4-py3-none-any.whl", hash = "sha256:717f80e7b15a9b18500c669777a0eed16e57744ff4bd632eb9bb949f8b8a8cf8"},
-    {file = "agently_stage-0.3.4.tar.gz", hash = "sha256:283a2e32bab0fd748fa39a239c18ab9ddfd044c690f1b8ec91c9cf9ff6904d65"},
+    {file = "agently_stage-0.3.5-py3-none-any.whl", hash = "sha256:9a1f709a70fc7295f94708db263da8b201bc511fcd52bcb6127827021464dbb8"},
+    {file = "agently_stage-0.3.5.tar.gz", hash = "sha256:ad86f515138c470655211adecc464a6d5efae3081127d5f590eabfb61b07c6fe"},
 ]
 
 [[package]]
@@ -745,4 +745,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "ef9699a4cb8c3265ba2acb4e3e16b6620cb09accac0dc10b11504b4fd5facb5e"
+content-hash = "94bc904006ef28ec2f6b7829001edce33c268ba8dce46fa499271dd5dea59f50"

--- a/tests/test_compatibility_registry.py
+++ b/tests/test_compatibility_registry.py
@@ -33,6 +33,21 @@ def test_current_release_manifest_matches_registry_release_file() -> None:
     assert current_manifest["release_train"] == release_manifest["release_train"]
 
 
+def test_4_1_4_5_release_manifest_pins_stage_native_runtime_contract() -> None:
+    manifest = get_current_release_manifest()
+
+    assert CURRENT_FRAMEWORK_VERSION == "4.1.4.5"
+    assert CURRENT_RELEASE_TRAIN == "2026-07-4.1.4.5"
+    stage_support = manifest["runtime_support"]["agently_stage"]
+    assert stage_support["version_specifier"] == ">=0.3.5,<0.4.0"
+    assert stage_support["task_mechanism_owners"] == ["TriggerFlowExecution"]
+    assert stage_support["public_runtime_surface"] is False
+    assert "EventCenter background task settlement" in stage_support[
+        "rejected_mechanism_replacements"
+    ]
+    assert stage_support["semantic_owners_unchanged"] is True
+
+
 def test_companion_views_still_derive_from_released_manifest() -> None:
     current = get_current_release_manifest()
     devtools = get_devtools_compatibility_manifest()

--- a/tests/test_release_workflow_docs.py
+++ b/tests/test_release_workflow_docs.py
@@ -22,3 +22,20 @@ def test_release_workflows_require_foundation_example_effect_gate():
         assert "ask the maintainer" in text or "请示维护者" in text
         assert "recommended usage" in text or "推荐用法" in text
         assert "all-allowed test capability policy" in text or "全开的测试 capability" in text
+
+
+def test_4_1_4_5_release_notes_are_linked_from_public_indexes():
+    english_notes = ROOT / "docs/en/development/release-notes-4.1.4.5.md"
+    chinese_notes = ROOT / "docs/cn/development/release-notes-4.1.4.5.md"
+
+    assert english_notes.exists()
+    assert chinese_notes.exists()
+    for path in (
+        ROOT / "README.md",
+        ROOT / "README_CN.md",
+        ROOT / "docs/en/index.md",
+        ROOT / "docs/cn/index.md",
+        ROOT / "docs/en/development/README.md",
+        ROOT / "docs/cn/development/README.md",
+    ):
+        assert "release-notes-4.1.4.5.md" in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Release scope

- opt-in `AgentExecution.ensure_long_output()` continuation for observed incomplete/length terminals
- direct Agently-Stage ownership of TriggerFlow process-local managed tasks
- Stage-backed sync/async call bridges while retaining `FunctionShifter` as a deprecated compatibility facade
- bilingual release notes, public indexes, README version guidance, and 4.1.4.5 compatibility manifest
- Poetry 2.2.1 lock against published `agently-stage` 0.3.5 artifacts

## Final validation

- exact release HEAD: 2508 passed, 27 skipped
- pyright: 0 errors
- `poetry check --lock`: passed
- Agently 4.1.4.5 wheel and sdist build: passed
- distribution metadata check: passed
- clean environment installed local Agently 4.1.4.5 wheel plus public PyPI Agently-Stage 0.3.5
- installed smoke proved version/manifest alignment, real Stage ownership, emit/handler settlement, and hidden runtime-stream close
- Stage-native performance A/B: all metrics inside the predeclared 10% budget
- Agently-Devtools candidate compatibility: 123 passed, pyright 0 errors
- Agently-Skills static validation: all seven commands passed

## Dependencies completed

- AgentEra/Agently-Stage#23 merged
- `agently-stage` 0.3.5 published and clean-install verified
- Stage-native integration PR #338 merged into `dev`
- release branch rebased onto current `dev`

Ready to merge into `dev` for final `dev` to `main` release promotion.