### PR TITLE
Finalize Agently 4.1.4.5 release validation

### DIFF
--- a/agently/__init__.py
+++ b/agently/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .base import print_, async_print, AgentlyMain, Agent
+from ._version import version
 from .core import (
     AgentTask,
     TaskContext,
@@ -54,6 +55,7 @@ Agently = AgentlyMain()
 
 __all__ = [
     "Agently",
+    "version",
     "Agent",
     "AgentTask",
     "TaskContext",

--- a/agently/_version.py
+++ b/agently/_version.py
@@ -1,0 +1,15 @@
+# Copyright 2023-2026 AgentEra(Agently.Tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: str = "4.1.4.5"

--- a/agently/base.py
+++ b/agently/base.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Literal, Type, TYPE_CHECKING, TypeVar, Generic, cast
 
 from agently.builtins.hookers.RuntimeConsoleSinkHooker import coerce_runtime_log_profile
+from agently._version import version as package_version
 from agently.utils import DeprecationWarnings, LazyImport, Settings, create_logger
 from agently.utils.RequestScheduler import RequestScheduler
 from agently.core import (
@@ -257,6 +258,8 @@ A = TypeVar("A", bound=Agent)
 
 
 class AgentlyMain(Generic[A]):
+    version = package_version
+
     def __init__(self, AgentType: Type[A] = Agent):
         self.settings = settings
         self.plugin_manager = plugin_manager

--- a/docs/cn/development/release-notes-4.1.4.5.md
+++ b/docs/cn/development/release-notes-4.1.4.5.md
@@ -64,6 +64,18 @@ Agently 内部的调用形态桥接使用 Agently-Stage `StageCallBridge`。
 `FunctionShifter` 仍可导入，但只作为 deprecated 兼容 facade，并委托给同一个
 bridge；新的框架代码不应让它负责 task 生命周期。
 
+## 包版本查询
+
+包和默认 `Agently` facade 暴露相同的发布版本：
+
+```python
+import agently
+from agently import Agently
+
+assert agently.version == "4.1.4.5"
+assert Agently.version == agently.version
+```
+
 ## 性能特征
 
 Stage-native TriggerFlow 与旧私有 adapter 进行了两轮反向顺序本地 A/B，每个
@@ -80,6 +92,15 @@ variant 共记录 18 个样本：
 实验没有产生 pending-task、未消费异常或生命周期警告。这些数据证明的是本地开销
 可控，并不表示 Stage 会让 provider-bound 模型请求变快。
 
+## 核心变更
+
+| 范围 | 变更内容 | 推荐用法 | 兼容性 / 风险 | 证据 |
+|---|---|---|---|---|
+| Direct 长输出 | 在观察到 length/incomplete terminal 后增加可选的 append-only continuation | 在 direct `AgentExecution` 启动前调用 `.ensure_long_output()` | 增量能力且默认关闭；不能与显式 AgentTask strategy 同时使用 | 确定性协议测试、真实 DeepSeek 结构化运行、公开示例 |
+| TriggerFlow 任务生命周期 | 由真实 Agently-Stage 0.3.5 实例直接持有 execution-managed 本地任务 | 继续使用现有 TriggerFlow execution API；Agently 不公开暴露 Stage 对象 | 内部 owner 变化且实测开销受控；EventCenter 保持原生实现 | Stage ownership/settlement 测试、全量测试、性能 A/B |
+| 同步/异步桥接 | 内部 bridge 委托到 `StageCallBridge`；`FunctionShifter` 保留为 deprecated facade | 新框架代码直接使用 Stage bridge | 现有导入仍然可用 | FunctionShifter 兼容测试 |
+| 包元数据 | 增加 `agently.version` 和 `Agently.version` | 使用任一属性读取当前安装的 Agently 发布版本 | 增量能力 | 源码/包元数据一致性测试和安装 wheel smoke |
+
 ## 兼容性
 
 - Python：`>=3.10`
@@ -90,4 +111,3 @@ variant 共记录 18 个样本：
 
 4.1.4.4 的 ModelRequest、TriggerFlow snapshot、RecordStore retention 和
 companion protocol 契约继续受支持。
-

--- a/docs/en/development/release-notes-4.1.4.5.md
+++ b/docs/en/development/release-notes-4.1.4.5.md
@@ -71,6 +71,18 @@ Agently's internal call-shape bridges use Agently-Stage `StageCallBridge`.
 delegates to the same bridge; new framework code should not use it as a task
 lifecycle owner.
 
+## Package version inspection
+
+The package and the default `Agently` facade expose the same release version:
+
+```python
+import agently
+from agently import Agently
+
+assert agently.version == "4.1.4.5"
+assert Agently.version == agently.version
+```
+
 ## Performance characterization
 
 The Stage-native TriggerFlow candidate was compared with the previous private
@@ -88,6 +100,15 @@ No run emitted a pending-task, unconsumed-exception, or lifecycle warning.
 These numbers demonstrate bounded local overhead; they do not claim that Stage
 makes provider-bound model requests faster.
 
+## Core changes
+
+| Area | What changed | Recommended usage | Compatibility / risk | Evidence |
+|---|---|---|---|---|
+| Direct long output | Added opt-in, append-only continuation after an observed length/incomplete terminal | Call `.ensure_long_output()` before starting a direct `AgentExecution` | Additive and disabled by default; not compatible with explicit AgentTask strategy | Deterministic protocol suite, real DeepSeek structured run, public example |
+| TriggerFlow task lifecycle | A real Agently-Stage 0.3.5 instance directly owns execution-managed local tasks | Keep using existing TriggerFlow execution APIs; no Stage object is exposed publicly by Agently | Internal owner change with bounded measured overhead; EventCenter remains native | Stage ownership/settlement tests, full suite, performance A/B |
+| Sync/async bridge | Internal bridges delegate to `StageCallBridge`; `FunctionShifter` remains a deprecated facade | New framework code should use Stage bridges directly | Existing imports remain available | FunctionShifter compatibility tests |
+| Package metadata | Added `agently.version` and `Agently.version` | Read either attribute for the installed Agently release version | Additive | Source/package metadata consistency and installed-wheel smoke |
+
 ## Compatibility
 
 - Python: `>=3.10`
@@ -98,4 +119,3 @@ makes provider-bound model requests faster.
 
 The 4.1.4.4 ModelRequest, TriggerFlow snapshot, RecordStore retention, and
 companion protocol contracts remain supported.
-

--- a/tests/test_agent_execution_compatibility.py
+++ b/tests/test_agent_execution_compatibility.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 from typing import Annotated, Any
 
 import pytest
+from agently_stage import Stage
 from pydantic import BaseModel, Field
 
 from agently import Agently
@@ -1368,6 +1369,66 @@ def test_agent_execution_ensure_long_output_continues_plain_text_losslessly(tmp_
     assert long_output["manifest_ref"]["sha256"]
     assert long_output["final_digest"]
     assert long_output["final_ref_retention"] == "execution_private_staging"
+
+
+@pytest.mark.asyncio
+async def test_agent_execution_long_output_settles_stage_owned_continuation_tasks(
+    tmp_path,
+    monkeypatch,
+):
+    stage_origins: dict[int, list[str]] = {}
+    closed_snapshots: dict[int, Any] = {}
+    original_create_task = Stage.create_task
+    original_async_close = Stage.async_close
+
+    def record_create_task(
+        self,
+        coroutine,
+        *,
+        origin,
+        name=None,
+    ):
+        stage_origins.setdefault(id(self), []).append(origin)
+        return original_create_task(
+            self,
+            coroutine,
+            origin=origin,
+            name=name,
+        )
+
+    async def record_async_close(self, timeout=None):
+        await original_async_close(self, timeout=timeout)
+        closed_snapshots[id(self)] = self.snapshot()
+
+    monkeypatch.setattr(Stage, "create_task", record_create_task)
+    monkeypatch.setattr(Stage, "async_close", record_async_close)
+    MockAgentExecutionLongOutputRequester.reset()
+    agent = _create_long_output_test_agent(
+        MockAgentExecutionLongOutputRequester,
+        "ensure-long-output-stage-settlement",
+    ).use_task_workspace(tmp_path)
+
+    execution = agent.input("write a long document").ensure_long_output()
+    result = await execution.async_get_text()
+
+    continuation_stage_ids = [
+        stage_id
+        for stage_id, origins in stage_origins.items()
+        if "emit_nowait:event:VALIDATE" in origins
+    ]
+    assert result == "alpha-omega"
+    assert len(continuation_stage_ids) == 1
+    continuation_stage_id = continuation_stage_ids[0]
+    assert any(
+        origin.startswith("handler:")
+        for origin in stage_origins[continuation_stage_id]
+    )
+    assert continuation_stage_id in closed_snapshots
+    snapshot = closed_snapshots[continuation_stage_id]
+    assert snapshot.state == "closed"
+    assert snapshot.active_count == 0
+    assert snapshot.pending_root_count == 0
+    assert snapshot.unresolved_origins == ()
 
 
 def test_agent_execution_ensure_long_output_separates_text_anchor_from_continuity_context(

--- a/tests/test_main_package.py
+++ b/tests/test_main_package.py
@@ -2,10 +2,13 @@ import asyncio
 import logging
 import sys
 import warnings
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
+import agently
 import pytest
+import toml
 import yaml
 from typing_extensions import assert_type
 
@@ -39,6 +42,18 @@ _RUNTIME_LOG_KEYS = (
     "runtime.show_runtime_logs",
     "runtime.httpx_log_level",
 )
+
+
+def test_package_exposes_release_version() -> None:
+    pyproject = toml.loads(
+        (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    expected_version = pyproject["project"]["version"]
+
+    assert agently.version == expected_version
+    assert Agently.version == expected_version
 
 
 def test_public_core_instance_creation_styles(tmp_path, monkeypatch):


### PR DESCRIPTION
## Scope

- expose `agently.version` and `Agently.version` from one package-owned constant
- enforce equality with `[project].version`
- add a cross-layer long-output regression proving continuation/validation tasks are Stage-owned and fully settled after close
- add the required bilingual core-changes table and version-inspection example

## Validation

- focused release/runtime suite: 135 passed
- full suite: 2510 passed, 27 skipped, 177 expected warnings
- source pyright with Python 3.10: 0 errors, 0 warnings
- `poetry check --lock`: passed
- `git diff --check`: passed
- wheel/sdist build and `twine check`: passed
- clean external install: Agently 4.1.4.5 + Agently-Stage 0.3.5, Stage close state `closed`
- installed-package pyright smoke: 0 errors, 0 warnings
- LazyImport missing-dependency smoke: structured `lazy_import.dependency/v1` error passed

## Real-model long-output acceptance

DeepSeek `deepseek-v4-flash`, thinking disabled, 2,000-token response ceiling, maximum 18 model requests / 600 seconds:

- accepted in 8 model requests / 64.914 s
- manifest revision 8
- 77 accepted units / 77 replayed units
- transport, schema, and declared coverage all complete
- zero no-progress events
- one stale unit rejected without losing its valid prefix; execution recovered and completed
- exact business cardinality remained model-owned and is explicitly not claimed by the transport acceptance

The earlier generic example attempt with DeepSeek thinking enabled produced empty continuation bodies after hidden reasoning consumed the 400-token ceiling. It is retained as a provider/configuration diagnostic and is not counted as passing evidence.
