### PR TITLE
fix: keep sandbox provider selection out of core

### DIFF
--- a/agently/core/operation/Action/ActionResourceRegistrar.py
+++ b/agently/core/operation/Action/ActionResourceRegistrar.py
@@ -38,15 +38,13 @@ class ActionResourceRegistrar:
         self._action = action
 
     @staticmethod
-    def _normalize_code_sandbox(value: Literal["auto", "docker", "gvisor", "landlock", "seatbelt", "trusted_local"] | str) -> Literal["auto", "docker", "gvisor", "landlock", "seatbelt", "trusted_local"]:
+    def _normalize_code_sandbox(value: Literal["auto", "docker", "trusted_local"] | str) -> Literal["auto", "docker", "trusted_local"]:
         normalized = str(value or "trusted_local").strip().lower().replace("-", "_")
         if normalized in {"local", "python", "node", "bash"}:
             normalized = "trusted_local"
-        if normalized in {"gvisor", "runsc", "gvisor/runsc"}:
-            normalized = "gvisor"
-        if normalized not in {"auto", "docker", "gvisor", "landlock", "seatbelt", "trusted_local"}:
-            raise ValueError("sandbox must be one of: 'auto', 'docker', 'gvisor', 'landlock', 'seatbelt', 'trusted_local'.")
-        return cast(Literal["auto", "docker", "gvisor", "landlock", "seatbelt", "trusted_local"], normalized)
+        if normalized not in {"auto", "docker", "trusted_local"}:
+            raise ValueError("sandbox must be one of: 'auto', 'docker', 'trusted_local'.")
+        return cast(Literal["auto", "docker", "trusted_local"], normalized)
 
     @staticmethod
     def _normalize_dependency_policy(value: Literal["deny", "request", "install"] | dict[str, Any] | str) -> dict[str, Any]:
@@ -106,7 +104,6 @@ class ActionResourceRegistrar:
         provisioning_profile: Literal["strict", "developer", "ci"] | str = "strict",
         image_pull_policy: Literal["never", "request", "if_missing", "always"] | str | None = None,
         runtime_profile: dict[str, Any] | None = None,
-        provider_id: str = "docker",
     ) -> "ExecutionResourceRequirement":
         normalized_provisioning_profile = self._normalize_provisioning_profile(provisioning_profile)
         normalized_dependency_policy = (
@@ -148,7 +145,6 @@ class ActionResourceRegistrar:
                 "default_args": docker_default_args or [],
                 "runtime_profile": profile,
             },
-            "provider_id": provider_id,
             "policy": self._docker_policy(default_policy, timeout=timeout),
         })
         if normalized_dependency_policy.get("mode") == "request" or normalized_image_pull_policy == "request":
@@ -322,7 +318,7 @@ class ActionResourceRegistrar:
         preset_objects: dict[str, object] | None = None,
         base_vars: dict[str, Any] | None = None,
         allowed_return_types: list[type] | None = None,
-        sandbox: Literal["auto", "docker", "gvisor", "landlock", "seatbelt", "trusted_local"] = "trusted_local",
+        sandbox: Literal["auto", "docker", "trusted_local"] = "trusted_local",
         docker_image: str = "python:3.12-slim",
         docker_binary: str = "docker",
         docker_default_args: list[str] | None = None,
@@ -346,14 +342,6 @@ class ActionResourceRegistrar:
             isolation = "none"
         elif sandbox_mode == "docker":
             providers = ["docker"]
-        elif sandbox_mode == "gvisor":
-            providers = ["gvisor"]
-        elif sandbox_mode == "seatbelt":
-            providers = ["seatbelt"]
-            isolation = "preferred"
-        elif sandbox_mode == "landlock":
-            providers = ["landlock"]
-            isolation = "preferred"
         return self.register_code_runtime_action(
             language="python",
             action_id=action_id,
@@ -388,7 +376,7 @@ class ActionResourceRegistrar:
         max_output_chars: int = 20000,
         output_artifact_dir: str | Path | None = None,
         task_workspace_mounts: list[dict[str, str]] | None = None,
-        sandbox: Literal["auto", "docker", "gvisor", "trusted_local"] = "trusted_local",
+        sandbox: Literal["auto", "docker", "trusted_local"] = "trusted_local",
         docker_image: str = "python:3.12-slim",
         docker_binary: str = "docker",
         docker_default_args: list[str] | None = None,
@@ -398,10 +386,6 @@ class ActionResourceRegistrar:
     ):
         action = self._action
         sandbox_mode = self._normalize_code_sandbox(sandbox)
-        if sandbox_mode in {"seatbelt", "landlock"}:
-            raise ValueError(
-                f"{sandbox_mode} supports Workspace-bound code_execution helpers, not the broad Bash sandbox action."
-            )
         model_desc = self._format_bash_sandbox_desc(
             desc,
             allowed_cmd_prefixes=allowed_cmd_prefixes,
@@ -450,7 +434,6 @@ class ActionResourceRegistrar:
                         "output_artifact_dir": str(output_artifact_dir) if output_artifact_dir is not None else None,
                         "task_workspace_mounts": [dict(item) for item in (task_workspace_mounts or [])],
                     },
-                    provider_id="gvisor" if sandbox_mode == "gvisor" else "docker",
                 )
             ]
         action.register_action(
@@ -494,7 +477,7 @@ class ActionResourceRegistrar:
         cwd: str | None = None,
         timeout: int = 20,
         env: dict[str, str] | None = None,
-        sandbox: Literal["auto", "docker", "gvisor", "landlock", "seatbelt", "trusted_local"] = "trusted_local",
+        sandbox: Literal["auto", "docker", "trusted_local"] = "trusted_local",
         docker_image: str = "node:22-slim",
         docker_binary: str = "docker",
         docker_default_args: list[str] | None = None,
@@ -517,14 +500,6 @@ class ActionResourceRegistrar:
             isolation = "none"
         elif sandbox_mode == "docker":
             providers = ["docker"]
-        elif sandbox_mode == "gvisor":
-            providers = ["gvisor"]
-        elif sandbox_mode == "seatbelt":
-            providers = ["seatbelt"]
-            isolation = "preferred"
-        elif sandbox_mode == "landlock":
-            providers = ["landlock"]
-            isolation = "preferred"
         return self.register_code_runtime_action(
             language="nodejs",
             action_id=action_id,
@@ -611,7 +586,7 @@ class ActionResourceRegistrar:
         has_unsafe_candidate = False
         for candidate in provider_candidates:
             candidate_config = dict(candidate.get("config", {}))
-            if candidate["provider_id"] in {"docker", "gvisor"}:
+            if candidate["provider_id"] == "docker":
                 candidate_runtime_profile = candidate_config.get("runtime_profile", {})
                 if not isinstance(candidate_runtime_profile, dict):
                     raise TypeError("Docker candidate runtime_profile must be a mapping.")

--- a/docs/cn/actions/execution-environment.md
+++ b/docs/cn/actions/execution-environment.md
@@ -119,6 +119,11 @@ agent.settings.set(
 agent.enable_code_runtime(language="go")
 ```
 
+`enable_python(...)` 与 `enable_nodejs(...)` 的 `sandbox=` 只是兼容快捷入口，仅支持
+`"auto"`、`"docker"` 和 `"trusted_local"`。可选隔离机制属于插件，必须通过下面的
+provider-neutral `providers=` 与 `isolation=` 参数选择。机制专属配置应放在对应 provider
+候选描述符中，不进入 core Action API。
+
 `trusted_local` 直接使用宿主 toolchain，没有隔离，只接受 snapshot grant。它需要显式
 host 授权，且不能满足 `isolation="required"`。因此 `unsafe_fallback=True` 必须同时
 显式选择 `isolation="preferred"` 或 `"none"`，不能被隐式选中。
@@ -131,10 +136,15 @@ syscall 限制。required isolation 必须满足全部请求轴；preferred isol
 
 ### gVisor Docker runtime
 
-当宿主 Docker daemon 已配置 `runsc` runtime 时，可显式选择 `gvisor`：
+当宿主 Docker daemon 已配置 `runsc` runtime 时，通过通用 code-runtime API 选择可选的
+`gvisor` provider：
 
 ```python
-agent.enable_python(sandbox="gvisor")
+agent.enable_code_runtime(
+    language="python",
+    providers=["gvisor"],
+    isolation="required",
+)
 ```
 
 该选择只使用可选的 `gvisor` provider。handle 就绪前，Agently 会验证 Docker
@@ -150,7 +160,11 @@ result metadata 中。gVisor 不会增加默认 import 依赖，也不会把不�
 在 macOS 上可以显式选择可选的 Seatbelt provider：
 
 ```python
-agent.enable_python(sandbox="seatbelt")
+agent.enable_code_runtime(
+    language="python",
+    providers=["seatbelt"],
+    isolation="preferred",
+)
 ```
 
 Seatbelt 使用系统 `sandbox-exec`，默认禁止网络，并且所有可写文件系统规则都只从
@@ -164,7 +178,11 @@ isolation；需要宿主读取隔离时应选择 Docker/gVisor。
 在支持 Landlock 的 Linux kernel 上，可以显式选择 filesystem-only provider：
 
 ```python
-agent.enable_python(sandbox="landlock")
+agent.enable_code_runtime(
+    language="python",
+    providers=["landlock"],
+    isolation="preferred",
+)
 ```
 
 Landlock 通过 provider 自有 helper 进程设置 `PR_SET_NO_NEW_PRIVS`，应用仅由

--- a/docs/cn/development/code-execution-provider-migration.md
+++ b/docs/cn/development/code-execution-provider-migration.md
@@ -73,6 +73,11 @@ agent.enable_code_runtime(language="python")
 候选配置只在该候选被 probe 或 ensure 时合并，因此不同机制的 provider 配置不会
 泄漏到核心 Action 契约。
 
+provider PR 不得把自己的 `provider_id`、别名、能力假设或配置分支加入 core Action
+helper，尤其不得为插件扩展兼容 `sandbox=` 枚举。应用应通过
+`enable_code_runtime(..., providers=[...], isolation=...)` 选择可选 provider；通用候选
+描述符必须原样传给被选中的 provider。
+
 容器运行时变体可以继承 `DockerExecutionResourceProvider`，只覆写
 `create_resource(...)` 来构造自己的 `DockerExecutionResource` 子类。继承的 provider
 复用 Workspace grant 绑定、镜像准备、健康检查与清理；有序选择与 ensure 前强制重新

--- a/docs/en/actions/execution-environment.md
+++ b/docs/en/actions/execution-environment.md
@@ -134,6 +134,13 @@ agent.settings.set(
 agent.enable_code_runtime(language="go")
 ```
 
+`sandbox=` on `enable_python(...)` and `enable_nodejs(...)` is a compatibility
+shortcut limited to `"auto"`, `"docker"`, and `"trusted_local"`. Optional
+isolation mechanisms are plugins: select them through the provider-neutral
+`providers=` and `isolation=` options shown below. A provider-specific
+configuration belongs in that provider's candidate descriptor, not in the core
+Action API.
+
 `trusted_local` executes host toolchains without isolation and accepts only a
 snapshot grant. It requires explicit host authorization and cannot satisfy
 `isolation="required"`. `unsafe_fallback=True` must therefore be paired with an
@@ -150,11 +157,15 @@ evidence.
 
 ### gVisor Docker runtime
 
-Use the explicit `gvisor` sandbox when the host Docker daemon is configured
-with the `runsc` runtime:
+When the host Docker daemon is configured with the `runsc` runtime, select the
+optional `gvisor` provider through the generic code-runtime API:
 
 ```python
-agent.enable_python(sandbox="gvisor")
+agent.enable_code_runtime(
+    language="python",
+    providers=["gvisor"],
+    isolation="required",
+)
 ```
 
 This chooses only the optional `gvisor` provider. Before a handle is ready,
@@ -171,7 +182,11 @@ dependency and does not make unsafe Docker arguments stronger safety evidence.
 On macOS, explicitly select the optional Seatbelt provider with:
 
 ```python
-agent.enable_python(sandbox="seatbelt")
+agent.enable_code_runtime(
+    language="python",
+    providers=["seatbelt"],
+    isolation="preferred",
+)
 ```
 
 Seatbelt uses the system `sandbox-exec` mechanism, denies network access by
@@ -188,7 +203,11 @@ On a Linux kernel with Landlock support, explicitly select the filesystem-only
 provider with:
 
 ```python
-agent.enable_python(sandbox="landlock")
+agent.enable_code_runtime(
+    language="python",
+    providers=["landlock"],
+    isolation="preferred",
+)
 ```
 
 Landlock runs a provider-owned helper process, applies `PR_SET_NO_NEW_PRIVS`

--- a/docs/en/development/code-execution-provider-migration.md
+++ b/docs/en/development/code-execution-provider-migration.md
@@ -80,6 +80,12 @@ Candidate configuration is merged only for the candidate being probed or
 ensured. This lets two candidates use different mechanisms without leaking
 provider-specific settings into the core Action contract.
 
+Provider PRs must not add their `provider_id`, aliases, capability assumptions,
+or configuration branches to core Action helpers. In particular, do not extend
+the compatibility `sandbox=` enum for a plugin. Applications select optional
+providers through `enable_code_runtime(..., providers=[...], isolation=...)`;
+the generic candidate descriptor is passed to the selected provider unchanged.
+
 Container-runtime variants can subclass `DockerExecutionResourceProvider` and
 override only `create_resource(...)` to construct their own
 `DockerExecutionResource` subclass. `ExecutionResourceManager` still owns

--- a/tests/test_gvisor_execution_provider.py
+++ b/tests/test_gvisor_execution_provider.py
@@ -196,9 +196,13 @@ async def test_gvisor_ensure_closes_unowned_resource_when_runtime_verification_i
     assert provider.created._closed is True
 
 
-def test_gvisor_sandbox_uses_only_the_gvisor_provider() -> None:
+def test_generic_selection_uses_only_the_gvisor_provider() -> None:
     action = _Action()
-    ActionResourceRegistrar(action).register_python_sandbox_action(sandbox="gvisor")
+    ActionResourceRegistrar(action).register_code_runtime_action(
+        language="python",
+        providers=["gvisor"],
+        isolation="required",
+    )
 
     requirement = action.registered["execution_resources"][0]
     assert requirement["kind"] == "code_execution"

--- a/tests/test_landlock_isolation.py
+++ b/tests/test_landlock_isolation.py
@@ -196,9 +196,13 @@ async def test_landlock_health_rechecks_real_mechanism(
     assert status == "unhealthy"
 
 
-def test_landlock_sandbox_uses_only_the_landlock_provider() -> None:
+def test_generic_selection_uses_only_the_landlock_provider() -> None:
     action = _Action()
-    ActionResourceRegistrar(action).register_python_sandbox_action(sandbox="landlock")
+    ActionResourceRegistrar(action).register_code_runtime_action(
+        language="python",
+        providers=["landlock"],
+        isolation="preferred",
+    )
 
     requirement = action.registered["execution_resources"][0]
     assert [item["provider_id"] for item in requirement["provider_candidates"]] == ["landlock"]

--- a/tests/test_provider_neutral_sandbox_selection.py
+++ b/tests/test_provider_neutral_sandbox_selection.py
@@ -1,0 +1,62 @@
+"""Core must not recognize optional ExecutionResourceProvider identities."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from agently.core.operation.Action.ActionResourceRegistrar import ActionResourceRegistrar
+
+
+class _Settings:
+    def get(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class _Action:
+    def __init__(self) -> None:
+        self.settings = _Settings()
+        self.registered: dict[str, Any] = {}
+
+    def _normalize_tags(self, _tags: Any) -> list[str]:
+        return []
+
+    def _create_executor(self, *_args: Any, **_kwargs: Any) -> object:
+        return object()
+
+    def register_action(self, **kwargs: Any) -> None:
+        self.registered = kwargs
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    ["gvisor", "runsc", "gvisor/runsc", "seatbelt", "landlock", "bubblewrap"],
+)
+def test_compatibility_sandbox_rejects_optional_provider_ids(provider_id: str) -> None:
+    with pytest.raises(ValueError):
+        ActionResourceRegistrar._normalize_code_sandbox(provider_id)
+
+
+@pytest.mark.parametrize("provider_id", ["gvisor", "seatbelt", "landlock"])
+def test_python_compatibility_helper_rejects_optional_provider_ids(provider_id: str) -> None:
+    with pytest.raises(ValueError):
+        ActionResourceRegistrar(cast(Any, _Action())).register_python_sandbox_action(
+            sandbox=cast(Any, provider_id)
+        )
+
+
+@pytest.mark.parametrize("provider_id", ["custom-isolator", "gvisor", "seatbelt", "landlock"])
+def test_generic_provider_candidate_descriptor_passes_through_unchanged(provider_id: str) -> None:
+    action = _Action()
+    candidate = {"provider_id": provider_id, "config": {"profile": "strict"}}
+
+    ActionResourceRegistrar(cast(Any, action)).register_code_runtime_action(
+        language="python",
+        providers=[candidate],
+        isolation="preferred",
+    )
+
+    requirement = action.registered["execution_resources"][0]
+    assert requirement["provider_candidates"] == [candidate]
+    assert requirement["meta"]["isolation_preference"] == "preferred"

--- a/tests/test_seatbelt_bugs.py
+++ b/tests/test_seatbelt_bugs.py
@@ -159,9 +159,13 @@ async def test_seatbelt_rejects_arbitrary_policy_configuration(
     assert raised.value.code == "execution_resource.seatbelt_config_invalid"
 
 
-def test_seatbelt_sandbox_uses_only_the_seatbelt_provider() -> None:
+def test_generic_selection_uses_only_the_seatbelt_provider() -> None:
     action = _Action()
-    ActionResourceRegistrar(action).register_python_sandbox_action(sandbox="seatbelt")
+    ActionResourceRegistrar(action).register_code_runtime_action(
+        language="python",
+        providers=["seatbelt"],
+        isolation="preferred",
+    )
 
     requirement = action.registered["execution_resources"][0]
     assert [item["provider_id"] for item in requirement["provider_candidates"]] == ["seatbelt"]


### PR DESCRIPTION
## What changed

- Restore the core `sandbox=` compatibility shortcut to `auto`, `docker`, and `trusted_local` only.
- Remove gVisor, runsc, Seatbelt, and Landlock ids, aliases, and routing branches from `ActionResourceRegistrar`.
- Pass every non-Docker provider candidate descriptor through unchanged.
- Select gVisor, Seatbelt, and Landlock in tests and public docs through the generic `providers=` plus `isolation=` contract.
- Add regression tests that reject optional provider ids at the compatibility boundary and protect descriptor pass-through.
- Synchronize coding-agent guidance in AgentEra/Agently-Skills#16.

## Root cause

The provider integrations correctly implemented optional `ExecutionResourceProvider` plugins, but their convenience wiring extended a core Action helper with concrete plugin identities and mechanism-specific configuration behavior. That inverted the intended dependency direction: core began knowing which optional providers existed.

## User and developer impact

`enable_python(sandbox=...)` and the related compatibility helpers accept only `auto`, `docker`, and `trusted_local`. Optional mechanisms use the stable generic form:

```python
agent.enable_code_runtime(
    language="python",
    providers=["gvisor"],
    isolation="required",
)
```

Provider implementations, default registration, lifecycle behavior, real mechanism checks, and contributor history are unchanged.

## Validation

- Focused owner/provider/Action suites: 212 passed.
- Full suite: 2581 passed, 29 skipped.
- New architecture regression file: pyright 0 errors.
- Full pyright: 32 existing errors, exactly matching unmodified `origin/dev`; this PR adds no type-check errors.
- Companion Skills repository: all seven standard static validators passed.

The gVisor, Seatbelt, and Landlock mechanism workflows are expected to run because the core registrar path changed.
