### PR TITLE
Fix Agently 4.1.4.7 release validation

### DIFF
--- a/.github/workflows/publish-on-version-change.yml
+++ b/.github/workflows/publish-on-version-change.yml
@@ -6,6 +6,13 @@ on:
       - main
     paths:
       - pyproject.toml
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: "Publish the current version after a failed validated release"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   validate:
@@ -71,26 +78,31 @@ jobs:
               current = read_version_from_text(f.read().decode("utf-8"))
           
           before = os.environ.get("GITHUB_EVENT_BEFORE", "")
-          if not before or before == "0000000000000000000000000000000000000000":
-              print("publish=true", file=open(os.environ["GITHUB_OUTPUT"], "a"))
-              sys.exit(0)
-          
-          try:
-              previous_text = subprocess.check_output(
-                  ["git", "show", f"{before}:pyproject.toml"],
-                  text=True,
-              )
-              previous = read_version_from_text(previous_text)
-          except Exception:
-              print("publish=true", file=open(os.environ["GITHUB_OUTPUT"], "a"))
-              sys.exit(0)
-          
-          publish = "true" if current != previous else "false"
+          event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+          force_publish = os.environ.get("FORCE_PUBLISH", "").strip().lower() == "true"
+          if event_name == "workflow_dispatch":
+              publish = "true" if force_publish else "false"
+          elif not before or before == "0000000000000000000000000000000000000000":
+              publish = "true"
+          else:
+              try:
+                  previous_text = subprocess.check_output(
+                      ["git", "show", f"{before}:pyproject.toml"],
+                      text=True,
+                  )
+                  previous = read_version_from_text(previous_text)
+              except Exception:
+                  publish = "true"
+              else:
+                  publish = "true" if current != previous else "false"
+
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               print(f"publish={publish}", file=f)
           PY
         env:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          FORCE_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && inputs.force_publish || 'false' }}
       - name: Install Poetry
         if: steps.version_check.outputs.publish == 'true'
         run: pipx install poetry

--- a/agently/builtins/plugins/ExecutionResourceProvider/LandlockExecutionHelper.py
+++ b/agently/builtins/plugins/ExecutionResourceProvider/LandlockExecutionHelper.py
@@ -142,7 +142,7 @@ def _load_manifest(path: Path) -> list[tuple[str, str]]:
         access = item.get("access")
         if not isinstance(raw_path, str) or not Path(raw_path).is_absolute():
             raise ValueError(f"rules[{index}].path must be absolute")
-        resolved = str(Path(raw_path).resolve())
+        resolved = raw_path if raw_path.startswith("/proc/") else str(Path(raw_path).resolve())
         if resolved != raw_path or not Path(resolved).exists():
             raise ValueError(f"rules[{index}].path must be canonical and existing")
         if access not in {"read", "write"}:

--- a/agently/builtins/plugins/ExecutionResourceProvider/LandlockExecutionResourceProvider.py
+++ b/agently/builtins/plugins/ExecutionResourceProvider/LandlockExecutionResourceProvider.py
@@ -45,6 +45,12 @@ def is_linux() -> bool:
     return platform.system() == "Linux"
 
 
+def _canonical_landlock_path(path: str) -> str:
+    if path.startswith("/proc/"):
+        return path
+    return str(Path(path).resolve())
+
+
 def _system_read_roots() -> list[str]:
     candidates = [
         "/usr",
@@ -61,6 +67,7 @@ def _system_read_roots() -> list[str]:
         "/dev/null",
         "/dev/urandom",
         "/dev/zero",
+        "/proc/self/exe",
         sys.executable,
     ]
     roots: list[str] = []
@@ -68,7 +75,7 @@ def _system_read_roots() -> list[str]:
         path = Path(candidate)
         if not path.exists():
             continue
-        resolved = str(path.resolve())
+        resolved = _canonical_landlock_path(candidate)
         if resolved not in roots:
             roots.append(resolved)
     return roots
@@ -211,7 +218,7 @@ class LandlockCodeExecutionResource:
             candidate = Path(path)
             if not candidate.exists():
                 return
-            resolved = str(candidate.resolve())
+            resolved = _canonical_landlock_path(path)
             if rules.get(resolved) == "write":
                 return
             rules[resolved] = access

--- a/docs/cn/development/release-workflows.md
+++ b/docs/cn/development/release-workflows.md
@@ -266,6 +266,11 @@ Desktop installers 不属于当前主仓库 release 流程。
 Agently-Stage），先运行 typing 与测试；随后 publish job 检测 Agently package version
 是否变化，并只在 version 变化时使用 Poetry 发布。
 
+如果该版本变更 push 之后 validation 失败，应通过新 PR 修复，再手动运行同一 workflow
+并设置 `force_publish=true`。手动触发默认不发布，只用于完整 validation matrix
+通过后恢复“版本号未再变化但制品从未成功上传”的版本。不要为了恢复失败 run 而再次
+提升 package version，也不要改为本地手工上传。
+
 PyPI 项目列表页展示的是包元数据 `Summary`，来源于 `pyproject.toml` 的 `[project].description`。项目内页展示完整 README，来源于 `[project].readme`。
 
 准备 release 时：

--- a/docs/en/development/release-workflows.md
+++ b/docs/en/development/release-workflows.md
@@ -317,6 +317,12 @@ dependencies, including Agently-Stage from PyPI, and runs typing and tests
 before the publish job. The publish job then detects whether the Agently package
 version changed and publishes with Poetry only when it changed.
 
+If validation fails after that version-changing push, fix the failure through a
+new PR and rerun the same workflow manually with `force_publish=true`. Manual
+dispatch defaults to no publish and exists only to recover an unchanged,
+previously unuploaded version after the complete validation matrix passes. Do
+not bump the package version or upload locally merely to recover a failed run.
+
 The PyPI project list page shows the package metadata `Summary`, which comes from `[project].description` in `pyproject.toml`. The full project page renders the README from `[project].readme`.
 
 When preparing a release:

--- a/tests/test_docker_workspace_code_execution.py
+++ b/tests/test_docker_workspace_code_execution.py
@@ -20,7 +20,39 @@ from agently.types.data import CodeExecutionRequest, TaskWorkspaceAccessRequirem
 
 
 @pytest.mark.asyncio
-async def test_docker_provider_exposes_code_execution_capabilities() -> None:
+async def test_docker_provider_exposes_code_execution_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        DockerExecutionResource,
+        "inspect_availability",
+        lambda _self: {
+            "available": True,
+            "reason": "ready",
+            "docker_binary": "docker",
+            "server_version": "29.0.0",
+        },
+    )
+    monkeypatch.setattr(
+        DockerExecutionResource,
+        "inspect_image",
+        lambda _self, image: {"exists": True, "image": image, "image_id": "sha256:test"},
+    )
+
+    async def inspect_toolchain(_self, *, image, tool, profile, timeout):
+        _ = image, profile, timeout
+        return {
+            "tool": tool,
+            "available": True,
+            "version": "3.12.0",
+            "raw_version": "Python 3.12.0",
+        }
+
+    monkeypatch.setattr(
+        DockerExecutionResource,
+        "inspect_toolchain",
+        inspect_toolchain,
+    )
     provider = DockerExecutionResourceProvider()
     probe = await provider.async_probe(
         requirement={
@@ -47,9 +79,14 @@ async def test_docker_provider_exposes_code_execution_capabilities() -> None:
 
 @pytest.mark.asyncio
 async def test_docker_executes_materialized_workspace_bundle(tmp_path: Path) -> None:
-    availability = DockerExecutionResource().inspect_availability()
+    docker_resource = DockerExecutionResource()
+    availability = docker_resource.inspect_availability()
     if not availability["available"]:
         pytest.skip(f"Docker is unavailable: {availability}")
+    image = "python:3.12-slim"
+    image_fact = docker_resource.inspect_image(image)
+    if not image_fact.get("exists"):
+        pytest.skip(f"required local Docker image is unavailable: {image}")
 
     workspace = TaskWorkspace(tmp_path / "workspace", execution_id="run-1")
     grant = workspace.issue_execution_access(
@@ -77,7 +114,7 @@ async def test_docker_executes_materialized_workspace_bundle(tmp_path: Path) -> 
             "task_workspace_access_grant": grant,
             "config": {
                 "runtime_profile": {
-                    "image": "python:3.12-slim",
+                    "image": image,
                     "image_pull_policy": "never",
                     "network_mode": "disabled",
                 }

--- a/tests/test_landlock_execution_provider_integration.py
+++ b/tests/test_landlock_execution_provider_integration.py
@@ -72,6 +72,6 @@ async def test_landlock_allows_granted_output_and_denies_ungranted_read(tmp_path
     )
 
     assert handle["meta"]["mechanism_verified"] is True
-    assert result["ok"] is True, result
+    assert result["ok"] is True, result.get("stderr", result)
     observed = json.loads((Path(grant.execution_area) / "output" / "result.json").read_text())
     assert observed == {"shadow_denied": True}

--- a/tests/test_landlock_isolation.py
+++ b/tests/test_landlock_isolation.py
@@ -12,6 +12,7 @@ import pytest
 from agently.builtins.plugins.ExecutionResourceProvider.LandlockExecutionResourceProvider import (
     LandlockCodeExecutionResource,
     LandlockExecutionResourceProvider,
+    _canonical_landlock_path,
 )
 from agently.builtins.plugins.ExecutionResourceProvider.LandlockExecutionHelper import (
     LANDLOCK_ACCESS_FS_MAKE_DIR,
@@ -33,6 +34,10 @@ from agently.types.data import (
 landlock_module = importlib.import_module(
     "agently.builtins.plugins.ExecutionResourceProvider.LandlockExecutionResourceProvider"
 )
+
+
+def test_landlock_preserves_proc_self_exe_virtual_path() -> None:
+    assert _canonical_landlock_path("/proc/self/exe") == "/proc/self/exe"
 
 
 def _grant(tmp_path: Path) -> TaskWorkspaceAccessGrant:

--- a/tests/test_multilanguage_code_execution_actual.py
+++ b/tests/test_multilanguage_code_execution_actual.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, TypedDict, cast
 
 import pytest
 
@@ -12,7 +13,11 @@ from agently.builtins.plugins.ExecutionResourceProvider.TrustedLocalExecutionRes
 from agently.core.TaskWorkspace import TaskWorkspace
 from agently.core import ExecutionResourceManager
 from agently.core.runtime import bind_runtime_context
-from agently.types.data import CodeExecutionRequest, TaskWorkspaceAccessRequirement
+from agently.types.data import (
+    CodeExecutionRequest,
+    ExecutionResourceProviderProbe,
+    TaskWorkspaceAccessRequirement,
+)
 from agently.utils import Settings
 
 
@@ -40,6 +45,13 @@ CASES = {
 }
 
 
+class _ObservedProbe(TypedDict):
+    available: bool
+    supported_kinds: list[str]
+    capabilities: dict[str, Any]
+    meta: dict[str, Any]
+
+
 @pytest.mark.parametrize("language", ["python", "nodejs", "go", "cpp"])
 @pytest.mark.asyncio
 async def test_locally_installed_mainstream_toolchain_executes_workspace_bundle(
@@ -47,7 +59,10 @@ async def test_locally_installed_mainstream_toolchain_executes_workspace_bundle(
     language: str,
 ) -> None:
     provider = TrustedLocalExecutionResourceProvider()
-    probe = await provider.async_probe(requirement={"kind": "code_execution"}, policy={})
+    probe = cast(
+        _ObservedProbe,
+        await provider.async_probe(requirement={"kind": "code_execution"}, policy={}),
+    )
     if language not in probe["capabilities"]["languages"]:
         pytest.skip(f"{language} toolchain unavailable: {probe['meta']['toolchains'][language]}")
     workspace = TaskWorkspace(
@@ -88,6 +103,20 @@ async def test_locally_installed_mainstream_toolchain_executes_workspace_bundle(
         }
         for item in bundle.toolchains
     }
+    required_capabilities = {
+        "language": language,
+        "toolchains": toolchains,
+        "workspace_access_mode": "snapshot",
+    }
+    if not ExecutionResourceManager._probe_is_eligible(
+        cast(ExecutionResourceProviderProbe, probe),
+        kind="code_execution",
+        required_capabilities=required_capabilities,
+    ):
+        pytest.skip(
+            f"{language} toolchain does not satisfy the bundle contract: "
+            f"{probe['meta']['toolchains'][language]}"
+        )
     manager = ExecutionResourceManager(
         plugin_manager=Agently.plugin_manager,
         settings=Settings(name=f"actual-{language}", parent=Agently.settings),
@@ -97,11 +126,7 @@ async def test_locally_installed_mainstream_toolchain_executes_workspace_bundle(
         {
             "kind": "code_execution",
             "provider_id": "trusted_local",
-            "required_capabilities": {
-                "language": language,
-                "toolchains": toolchains,
-                "workspace_access_mode": "snapshot",
-            },
+            "required_capabilities": required_capabilities,
             "config": {"allow_unsafe_local": True},
             "policy": {"max_output_bytes": 10_000},
             "task_workspace_access_grant": grant,
@@ -129,7 +154,10 @@ async def test_action_runtime_runs_workspace_bound_provider_chain_with_explicit_
     tmp_path: Path,
 ) -> None:
     provider = TrustedLocalExecutionResourceProvider()
-    probe = await provider.async_probe(requirement={"kind": "code_execution"}, policy={})
+    probe = cast(
+        _ObservedProbe,
+        await provider.async_probe(requirement={"kind": "code_execution"}, policy={}),
+    )
     if "python" not in probe["capabilities"]["languages"]:
         pytest.skip("Python toolchain is unavailable")
     workspace = TaskWorkspace(tmp_path / "action-workspace", execution_id="actual-action")

--- a/tests/test_release_workflow_docs.py
+++ b/tests/test_release_workflow_docs.py
@@ -4,6 +4,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def test_publish_workflow_has_an_explicit_failed_release_retry_path():
+    workflow = (ROOT / ".github/workflows/publish-on-version-change.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "workflow_dispatch:" in workflow
+    assert "force_publish:" in workflow
+    assert "FORCE_PUBLISH:" in workflow
+    assert "github.event_name == 'workflow_dispatch'" in workflow
+
+
 def test_release_workflows_require_foundation_example_effect_gate():
     english = (ROOT / "docs/en/development/release-workflows.md").read_text(encoding="utf-8")
     chinese = (ROOT / "docs/cn/development/release-workflows.md").read_text(encoding="utf-8")

--- a/tests/test_skill_script_action_binder.py
+++ b/tests/test_skill_script_action_binder.py
@@ -173,9 +173,13 @@ async def test_agent_exposes_explicit_script_binding_after_exact_skill_binding(
 async def test_bound_skill_script_executes_through_workspace_and_docker(
     tmp_path: Path,
 ) -> None:
-    availability = DockerExecutionResource().inspect_availability()
+    docker_resource = DockerExecutionResource()
+    availability = docker_resource.inspect_availability()
     if not availability["available"]:
         pytest.skip(f"Docker is unavailable: {availability}")
+    image = DockerExecutionResource._default_image("python")
+    if not docker_resource.inspect_image(image).get("exists"):
+        pytest.skip(f"required local Docker image is unavailable: {image}")
 
     skill_root = _write_skill(tmp_path / "skill", trust_marker="actual-docker")
     (skill_root / "scripts" / "check.py").write_text(


### PR DESCRIPTION
## Failed-release recovery

The initial 4.1.4.7 main validation correctly blocked publication on five CI-only environment assumptions.

Fixes:

- make Docker tests deterministic or skip when the required local image is absent;
- skip host toolchains that do not satisfy the bundle version contract;
- restore Landlock `/proc/self/exe` access required by GitHub-hosted Python;
- add a tested, default-off `workflow_dispatch(force_publish)` recovery path so the unchanged, never-uploaded version can be published only after the complete matrix passes.

Validation:

- focused affected tests: 21 passed, 1 non-Linux skip;
- focused pyright: 0 errors;
- workflow/docs tests: 3 passed;
- local pre-fix full suite was otherwise 2590 passed; the final authoritative 3.10/3.14 matrix will run through the manual publish workflow after this merge.

No package version change: 4.1.4.7 was not uploaded by the failed run.
