### PR TITLE
Fix Landlock virtualenv release validation

### DIFF
--- a/agently/builtins/plugins/ExecutionResourceProvider/LandlockExecutionResourceProvider.py
+++ b/agently/builtins/plugins/ExecutionResourceProvider/LandlockExecutionResourceProvider.py
@@ -81,14 +81,17 @@ def _system_read_roots() -> list[str]:
     return roots
 
 
-def _toolchain_root(command: str) -> str | None:
+def _toolchain_roots(command: str) -> list[str]:
     binary = shutil.which(command)
     if binary is None:
-        return None
-    path = Path(binary).resolve()
-    if str(path).startswith("/usr/"):
-        return "/usr"
-    return str(path.parent.parent)
+        return []
+    binary_path = Path(binary)
+    roots: list[str] = []
+    for path in (binary_path.parent.parent, binary_path.resolve().parent.parent):
+        normalized = "/usr" if str(path).startswith("/usr/") else str(path)
+        if normalized not in roots:
+            roots.append(normalized)
+    return roots
 
 
 def _probe_manifest() -> dict[str, Any]:
@@ -226,8 +229,7 @@ class LandlockCodeExecutionResource:
         for path in _system_read_roots():
             add(path, "read")
         if argv:
-            toolchain_root = _toolchain_root(argv[0])
-            if toolchain_root:
+            for toolchain_root in _toolchain_roots(argv[0]):
                 add(toolchain_root, "read")
         add(cwd, "read")
         for root in self.grant.roots:

--- a/tests/test_agent_task_loop.py
+++ b/tests/test_agent_task_loop.py
@@ -8119,7 +8119,7 @@ async def test_taskboard_preplanned_action_commands_dispatch_without_actionloop(
     assert direct is not None
     card_output, execution_meta = direct
     assert card_output["status"] == "completed"
-    assert calls == ["NVDA", "AVGO"]
+    assert sorted(calls) == ["AVGO", "NVDA"]
     assert [record["action_id"] for record in execution_meta["logs"]["action_logs"]] == [
         "market_snapshot",
         "market_snapshot",
@@ -8148,7 +8148,7 @@ async def test_taskboard_preplanned_action_commands_dispatch_without_actionloop(
     )
 
     assert result.status == "completed"
-    assert calls == ["NVDA", "AVGO"]
+    assert sorted(calls) == ["AVGO", "NVDA"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_landlock_isolation.py
+++ b/tests/test_landlock_isolation.py
@@ -13,6 +13,7 @@ from agently.builtins.plugins.ExecutionResourceProvider.LandlockExecutionResourc
     LandlockCodeExecutionResource,
     LandlockExecutionResourceProvider,
     _canonical_landlock_path,
+    _toolchain_roots,
 )
 from agently.builtins.plugins.ExecutionResourceProvider.LandlockExecutionHelper import (
     LANDLOCK_ACCESS_FS_MAKE_DIR,
@@ -38,6 +39,22 @@ landlock_module = importlib.import_module(
 
 def test_landlock_preserves_proc_self_exe_virtual_path() -> None:
     assert _canonical_landlock_path("/proc/self/exe") == "/proc/self/exe"
+
+
+def test_landlock_preserves_virtualenv_and_resolved_toolchain_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    virtualenv_root = tmp_path / "venv"
+    binary = virtualenv_root / "bin" / "python"
+    binary.parent.mkdir(parents=True)
+    binary.symlink_to(sys.executable)
+    monkeypatch.setattr(landlock_module.shutil, "which", lambda _command: str(binary))
+
+    roots = _toolchain_roots("python")
+
+    assert str(virtualenv_root) in roots
+    assert str(Path(sys.executable).resolve().parent.parent) in roots
 
 
 def _grant(tmp_path: Path) -> TaskWorkspaceAccessGrant:


### PR DESCRIPTION
## Linux/Python 3.14 release validation fix

- Preserve both the original virtualenv root and resolved base-interpreter root in Landlock read rules, so Python can read `pyvenv.cfg` after restriction.
- Retain `/proc/self/exe` as a virtual path.
- Make the concurrent TaskBoard Action test assert exact membership rather than scheduler-dependent call order.

Evidence:

- focused pyright: 0 errors;
- focused tests: 10 passed, 1 non-Linux skip;
- previous recovery matrix reduced failures to this Landlock startup issue on 3.10/3.14 plus the order-only assertion on 3.14.
