### PR TITLE
docs: add OrcaRouter provider recipe

### DIFF
--- a/docs/cn/models/providers/index.md
+++ b/docs/cn/models/providers/index.md
@@ -1,7 +1,7 @@
 ---
 title: Provider 配置
 description: 按模型 provider 分组的配置 recipe —— base URL、环境变量、模型名占位。
-keywords: Agently, providers, OpenAI, DeepSeek, Qwen, Claude, Ollama, recipes
+keywords: Agently, providers, OpenAI, DeepSeek, Qwen, Claude, Ollama, OrcaRouter, recipes
 ---
 
 # Provider 配置
@@ -178,6 +178,18 @@ Agently.set_settings("OpenAICompatible", {
     "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
     "api_key": "${ENV.GEMINI_API_KEY}",
     "model": "${ENV.GEMINI_MODEL}",
+})
+```
+
+## OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个 OpenAI 兼容的 meta-router，把每次请求路由到你从众多 provider 中挑选的模型。自动路由模型 `orcarouter/auto` 开箱即用，也可以固定命名空间 id，如 `openai/gpt-5.5`：
+
+```python
+Agently.set_settings("OpenAICompatible", {
+    "base_url": "https://api.orcarouter.ai/v1",
+    "api_key": "${ENV.ORCAROUTER_API_KEY}",
+    "model": "orcarouter/auto",   # 自动路由，或固定如 "openai/gpt-5.5"
 })
 ```
 

--- a/docs/en/models/providers/index.md
+++ b/docs/en/models/providers/index.md
@@ -1,7 +1,7 @@
 ---
 title: Provider Recipes
 description: Configuration recipes per model provider — base URLs, env vars, and model-name placeholders.
-keywords: Agently, providers, OpenAI, DeepSeek, Qwen, Claude, Ollama, recipes
+keywords: Agently, providers, OpenAI, DeepSeek, Qwen, Claude, Ollama, OrcaRouter, recipes
 ---
 
 # Provider Recipes
@@ -178,6 +178,18 @@ Agently.set_settings("OpenAICompatible", {
     "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
     "api_key": "${ENV.GEMINI_API_KEY}",
     "model": "${ENV.GEMINI_MODEL}",
+})
+```
+
+## OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible meta-router that routes each request to a model of your choice across many providers. The auto-routing `orcarouter/auto` model works out of the box; you can also pin a namespaced id such as `openai/gpt-5.5`:
+
+```python
+Agently.set_settings("OpenAICompatible", {
+    "base_url": "https://api.orcarouter.ai/v1",
+    "api_key": "${ENV.ORCAROUTER_API_KEY}",
+    "model": "orcarouter/auto",   # auto-routing, or pin e.g. "openai/gpt-5.5"
 })
 ```
 


### PR DESCRIPTION
## Summary

Adds a dedicated [OrcaRouter](https://www.orcarouter.ai) provider recipe to the model providers docs (English + Chinese), mirroring how this repo already treats DeepSeek, Qwen and Groq as named OpenAI-compatible entries. Named routers such as `orcarouter/auto` pick an upstream per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models behind one API key, and it also provides gateway-level security controls for AI agents.

The recipe targets the existing `OpenAICompatible` requester with `base_url: https://api.orcarouter.ai/v1`, so users get a copy-paste block instead of guessing a generic gateway URL.

I'm an engineer on the OrcaRouter team.

I have read and agree to the CLA in CLA.md.

## How to use

```python
Agently.set_settings("OpenAICompatible", {
    "base_url": "https://api.orcarouter.ai/v1",
    "api_key": "${ENV.ORCAROUTER_API_KEY}",
    "model": "orcarouter/auto",   # auto-routing, or pin e.g. "openai/gpt-5.5"
})
```

## Validation

- Docs-only change; both `docs/en/models/providers/index.md` and `docs/cn/models/providers/index.md` updated.
- Frontmatter YAML parses, code fences balanced, all recipe Python blocks pass `ast.parse`.
- Live check: `POST https://api.orcarouter.ai/v1/chat/completions` with `model=orcarouter/auto` returns HTTP 200.
