### PR TITLE
docs: align Agently 4.1.4.7 with Skills catalog v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,10 @@ immutable installed revisions, AgentExecution owns selection and exact-revision
 binding, and TaskContext owns progressive disclosure. `agent.use_skills(...)`
 is the normal candidate-binding surface; `agent.require_skills(...)` binds a
 known exact revision. `Agently.skills_executor` remains a thin compatibility
-facade for installation, inspection, context projection, and TaskDAG helpers.
+facade for installation, inspection, and context projection. In the 4.1.4.7
+release, its legacy TaskDAG `skill` resolver helper is not an executor-ready
+integration: it still needs a host adapter from the real `TaskDAGContext` before
+node selectors reach the compatibility projection.
 
 ```python
 result = (
@@ -698,7 +701,7 @@ Archived examples live under `examples/archived/` and are compatibility referenc
 Agently-Skills gives coding agents current Agently implementation guidance.
 
 - Repository: https://github.com/AgentEra/Agently-Skills
-- Current catalog generation: `v2`
+- Current catalog generation: `v3`
 - Recommended bundle: `app`
 - Agently 4.1.4.7 compatibility: Skills authoring protocol `agently-skills.authoring.v2`
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -353,8 +353,10 @@ raw = agent.action.read_action_artifact(
 Skills 是可复用的任务指导包。在当前发布中，`SkillLibrary` 负责不可变的已安装
 revision，AgentExecution 负责选择和精确 revision binding，TaskContext 负责渐进
 disclosure。`agent.use_skills(...)` 是普通候选绑定入口；已知精确 revision 时使用
-`agent.require_skills(...)`。`Agently.skills_executor` 只保留安装、检查、context
-projection 与 TaskDAG helper 的轻量兼容 facade。
+`agent.require_skills(...)`。`Agently.skills_executor` 只保留安装、检查与 context
+projection 的轻量兼容 facade。在 4.1.4.7 公开版本中，其历史 TaskDAG `skill`
+resolver helper 并不是可直接交给 executor 的完整集成；真实 `TaskDAGContext` 仍需经过宿主 adapter，
+node selector 才能进入兼容投影。
 
 ```python
 result = (
@@ -685,7 +687,7 @@ Prompt 文件可以承载 Prompt 槽位和输出契约：
 Agently-Skills 为 coding agent 提供当前 Agently 实现指导。
 
 - Repository: https://github.com/AgentEra/Agently-Skills
-- 当前 catalog generation: `v2`
+- 当前 catalog generation: `v3`
 - 推荐 bundle: `app`
 - Agently 4.1.4.7 compatibility: Skills authoring protocol `agently-skills.authoring.v2`
 

--- a/compatibility/in-development.json
+++ b/compatibility/in-development.json
@@ -97,14 +97,14 @@
         "installed_truth_owner": "SkillLibrary immutable content-addressed revisions",
         "selection_and_binding_owner": "AgentExecution structured semantic selection with host-issued keys and fail-closed validation",
         "disclosure_owner": "TaskContext plus SkillContextSource plus consumer-bound ContextReader",
-        "compatibility_facade": "Agently.skills_executor supports local configure/install/list/inspect/read/context-pack/TaskDAG helpers only",
+        "compatibility_facade": "Agently.skills_executor supports local configure/install/list/inspect/read/context-pack projection. Its legacy TaskDAG skill resolver helper is not executor-ready until host code adapts the real TaskDAGContext into the helper's mapping input.",
         "execution_policy": "No Skills route, Skill-local strategy, stage engine, implicit script actionization, capability inference, or capability mounting; trusted exact-revision scripts require explicit host authorization and bind as ordinary Workspace-backed code_execution Actions",
         "revision_binding_event": "skills.revisions.bound records exact revision availability without claiming activation",
         "context_consumption_event": "skills.context.bound records concrete ModelRequest response-bound context consumption; availability alone is not consumption or Action evidence",
         "remote_source_policy": "Registered SkillSourceProvider plugins materialize authorized local or Git sources to immutable local snapshots; SkillLibrary installs exact snapshots and records redacted provenance; remote compatibility installs default to untrusted and selected subpaths reject symlink escape"
       },
       "devtools_guidance_protocol": "agently-skills.devtools-guidance.v1",
-      "catalog_generation": "v2",
+      "catalog_generation": "v3",
       "recommended_bundle": "app",
       "recommended_ref": "main",
       "runtime_dependency_guidance": {
@@ -114,6 +114,12 @@
         }
       },
       "archived_catalog_generations": [
+        {
+          "generation": "v2",
+          "branch": "update/archive-v2-catalog",
+          "last_supported_framework_version": "4.1.4.7",
+          "status": "frozen"
+        },
         {
           "generation": "v1",
           "branch": "update/archive-legacy-v1-catalog",

--- a/docs/cn/development/coding-agents.md
+++ b/docs/cn/development/coding-agents.md
@@ -41,11 +41,13 @@ skill **不是**纯文档。它为 coding agent 结构化：每个 skill 告诉 
 | `agently-design` | 设计或审计跨 ModelRequest、证据、生命周期、并发或可观测性的非简单系统拓扑 |
 | `agently-request` | 模型接入、Prompt 管理、结构化输出、响应复用、session memory、embedding、检索 |
 | `agently-runtime` | Action Runtime、内置 actions、MCP、ExecutionResource、FastAPI 暴露、DevTools 接入 |
-| `agently-dynamic-task` | 模型生成或应用提交的 DAG 规划、校验和执行 |
+| `agently-stage` | Agently-Stage 进程内任务生命周期、sync/async 桥接、settlement、replay channel 和本地 listener |
 | `agently-triggerflow` | 需要分支、并发、pause/resume、save/load |
 | `agently-migration` | 从 LangChain、LangGraph、LlamaIndex、CrewAI 或类似系统迁移 |
 
-当前公开 catalog generation 是 `v2`。实际默认 skill 列表见 `Agently-Skills/skills/`，应只包含这 7 个 skills。
+当前公开 catalog generation 是 `v3`。实际公开 skill 列表见 `Agently-Skills/skills/`，应只包含这 7 个 skills。
+
+TaskDAG 和 `DynamicTask` 便利 facade 仍是受支持的框架 API。由于模型生成或应用提交 DAG 属于低频应用路径，它不再占用一个独立 coding-agent skill。从 `agently` 开始，只在实际需要该能力时按需读取其 TaskDAG / Dynamic Task reference。
 
 ## 安装
 
@@ -69,7 +71,7 @@ for skill in \
   agently-design \
   agently-request \
   agently-runtime \
-  agently-dynamic-task \
+  agently-stage \
   agently-triggerflow
 do
   npx skills add AgentEra/Agently-Skills --agent "$AGENT" --skill "$skill" -y
@@ -77,7 +79,8 @@ done
 ```
 
 只有迁移项目才额外安装 `agently-migration`。历史 catalog 通过冻结归档分支保留，
-而不是放在默认分支文件树里；V1 12-skill catalog 归档在
+而不是放在默认分支文件树里：V2 归档在 `update/archive-v2-catalog`，
+最后支持 Agently `4.1.4.7`；V1 12-skill catalog 归档在
 `update/archive-legacy-v1-catalog`，最后支持 Agently `4.1.1`。新项目不要把归档
 catalog 加入 coding agent 的常规搜索路径。
 

--- a/docs/cn/development/skills-executor.md
+++ b/docs/cn/development/skills-executor.md
@@ -72,6 +72,12 @@ facade 只保留已经发布的 Skill 管理和投影调用：
 - 构造兼容 context-pack projection；
 - 提供 TaskDAG `skill` resolver helper。
 
+该 TaskDAG helper 是历史兼容 seam，在 4.1.4.7 中不是已经完整接通的
+`TaskDAGExecutor` integration。真实 executor 传入 `TaskDAGContext`，而 helper
+消费 mapping-shaped projection，因此宿主仍需
+适配这个边界。在框架拥有 adapter 和端到端 executor test 之前，不应把直接注册
+描述为已验证路径；后续 release line 需要重新核验该限制。
+
 它不负责 route selection、effort strategy、stage、React loop、runtime chain、
 Blocks lowering、script execution、capability inference、自动 Action mounting 或审批。
 已注册的 `SkillSourceProvider` 可以把已授权远程 source 落成不可变本地 snapshot；

--- a/docs/cn/start/project-framework.md
+++ b/docs/cn/start/project-framework.md
@@ -12,7 +12,7 @@ keywords: Agently, 项目结构, 拓扑, TriggerFlow, Dynamic Task, FastAPI, Fas
 边界所需的最小文件结构。
 
 完整可运行示例见 Agently-Skills 的
-[`skills/agently/assets/project-template`](https://github.com/AgentEra/Agently-Skills/tree/main/skills/agently/assets/project-template)
+[`skills/agently/assets/full-stack-reference`](https://github.com/AgentEra/Agently-Skills/tree/main/skills/agently/assets/full-stack-reference)
 资产。它为演示目的同时包含多种可选边界；小型应用应按需取用，不要把它当成必须
 整套复制的脚手架。
 

--- a/docs/en/development/coding-agents.md
+++ b/docs/en/development/coding-agents.md
@@ -41,11 +41,13 @@ The companion repo does not become a runtime dependency of your Agently app. It 
 | `agently-design` | designing or auditing a non-trivial cross-layer ModelRequest, evidence, lifecycle, concurrency, or observability topology |
 | `agently-request` | model setup, prompt management, structured output, response reuse, session memory, embeddings, retrieval |
 | `agently-runtime` | Action Runtime, built-in actions, MCP, ExecutionResource, FastAPI exposure, DevTools wiring |
-| `agently-dynamic-task` | model-generated or app-submitted DAG planning, validation, and execution |
+| `agently-stage` | Agently-Stage process-local lifetime, sync/async bridging, settlement, replay channels, and local listeners |
 | `agently-triggerflow` | needing branching, concurrency, pause/resume, save/load |
 | `agently-migration` | migrating from LangChain, LangGraph, LlamaIndex, CrewAI, or similar systems |
 
-The current public catalog generation is `v2`. The actual default skill list lives in `Agently-Skills/skills/` and should contain only these 7 skills.
+The current public catalog generation is `v3`. The actual public skill list lives in `Agently-Skills/skills/` and should contain only these 7 skills.
+
+TaskDAG and the `DynamicTask` convenience facade remain supported framework APIs. Because model-generated or app-submitted DAG work is a less common application path, it no longer has a standalone coding-agent skill. Start with `agently` and load its TaskDAG / Dynamic Task reference only when that capability is actually needed.
 
 ## Installing the skills
 
@@ -69,14 +71,14 @@ for skill in \
   agently-design \
   agently-request \
   agently-runtime \
-  agently-dynamic-task \
+  agently-stage \
   agently-triggerflow
 do
   npx skills add AgentEra/Agently-Skills --agent "$AGENT" --skill "$skill" -y
 done
 ```
 
-Add `agently-migration` only for migration projects. Historical catalogs are kept on frozen archive branches instead of the default branch; the V1 12-skill catalog is archived on `update/archive-legacy-v1-catalog` and last supports Agently `4.1.1`. Do not add archived catalogs to a coding agent's normal search path for new projects.
+Add `agently-migration` only for migration projects. Historical catalogs are kept on frozen archive branches instead of the default branch: V2 is archived on `update/archive-v2-catalog` and last supports Agently `4.1.4.7`; V1 is archived on `update/archive-legacy-v1-catalog` and last supports Agently `4.1.1`. Do not add archived catalogs to a coding agent's normal search path for new projects.
 
 ## Why skills, not just docs
 

--- a/docs/en/development/skills-executor.md
+++ b/docs/en/development/skills-executor.md
@@ -79,6 +79,13 @@ Skills:
 - build a compatibility context-pack projection;
 - expose the TaskDAG `skill` resolver helper.
 
+That TaskDAG helper is a legacy compatibility seam, not a complete
+`TaskDAGExecutor` integration in 4.1.4.7. The real executor passes
+`TaskDAGContext` while the helper consumes a
+mapping-shaped projection. Host code would have to adapt that boundary. Do not
+present direct registration as proven until the framework owns the adapter and
+an end-to-end executor test; reverify this limitation for later release lines.
+
 It does not own route selection, effort strategies, stages, React loops,
 runtime chains, Blocks lowering, script execution, capability inference,
 automatic Action mounting, or approvals. A registered `SkillSourceProvider`

--- a/docs/en/start/project-framework.md
+++ b/docs/en/start/project-framework.md
@@ -11,7 +11,7 @@ real owners and consumers first, then create the smallest file layout that
 carries those boundaries.
 
 For a complete runnable example, see the Agently-Skills
-[`skills/agently/assets/project-template`](https://github.com/AgentEra/Agently-Skills/tree/main/skills/agently/assets/project-template)
+[`skills/agently/assets/full-stack-reference`](https://github.com/AgentEra/Agently-Skills/tree/main/skills/agently/assets/full-stack-reference)
 asset. It intentionally demonstrates several optional boundaries at once. Copy
 it selectively; it is not a mandatory scaffold for a small application.
 

--- a/examples/skills_executor/07_agently_skills_availability_check.py
+++ b/examples/skills_executor/07_agently_skills_availability_check.py
@@ -36,23 +36,25 @@ from agently import Agently
 #
 # Expected key output from one local run:
 # pack_status=success
-# installed_count=6
+# installed_count=7
 #
-# Installed Agently-Skills (6):
+# Installed Agently-Skills (7):
 #   agently:
-#   agently-dynamic-task:
+#   agently-design:
 #   agently-migration:
 #   agently-request:
 #   agently-runtime:
+#   agently-stage:
 #   agently-triggerflow:
 #
 # Availability check (deterministic planner, no model call):
-#   agently              → resolved
-#   agently-dynamic-task → resolved
-#   agently-migration    → resolved
-#   agently-request      → resolved
-#   agently-runtime      → resolved
-#   agently-triggerflow  → resolved
+#   agently             → resolved
+#   agently-design      → resolved
+#   agently-migration   → resolved
+#   agently-request     → resolved
+#   agently-runtime     → resolved
+#   agently-stage       → resolved
+#   agently-triggerflow → resolved
 #
 # all_available=True
 #

--- a/examples/skills_executor/README.md
+++ b/examples/skills_executor/README.md
@@ -6,8 +6,10 @@ indexed resources. `SkillLibrary` owns installation and package truth;
 `ContextReader` own progressive disclosure.
 
 `Agently.skills_executor` remains a thin management/compatibility facade. It
-can configure the library, install/list/inspect/read Skills, build compatibility
-context packs, and expose the TaskDAG helper. It does not choose execution
+can configure the library, install/list/inspect/read Skills, and build
+compatibility context packs. Its legacy TaskDAG helper is not an executor-ready
+integration until host code adapts the real `TaskDAGContext`; do not present
+direct registration as a working example. The facade does not choose execution
 routes, run Skill-local strategies, actionize scripts, or grant capabilities.
 
 Recommended execution:

--- a/tests/test_compatibility_registry.py
+++ b/tests/test_compatibility_registry.py
@@ -128,6 +128,8 @@ def test_in_development_skill_contract_reconnects_to_agent_execution() -> None:
     assert contract["selection_and_binding_owner"].startswith("AgentExecution")
     assert "TaskContext" in contract["disclosure_owner"]
     assert "Agently.skills_executor" in contract["compatibility_facade"]
+    assert "not executor-ready" in contract["compatibility_facade"]
+    assert "TaskDAGContext" in contract["compatibility_facade"]
     assert "No Skills route" in contract["execution_policy"]
     assert "SkillSourceProvider" in contract["remote_source_policy"]
     assert "immutable local snapshots" in contract["remote_source_policy"]
@@ -140,6 +142,24 @@ def test_in_development_skill_contract_reconnects_to_agent_execution() -> None:
     stage_guidance = skills["runtime_dependency_guidance"]["agently_stage"]
     assert stage_guidance["skill"] == "agently-stage"
     assert stage_guidance["version_specifier"] == stage_support["version_specifier"]
+
+    assert skills["catalog_generation"] == "v3"
+    archived_catalogs = {
+        entry["generation"]: entry
+        for entry in skills["archived_catalog_generations"]
+    }
+    assert archived_catalogs["v2"] == {
+        "generation": "v2",
+        "branch": "update/archive-v2-catalog",
+        "last_supported_framework_version": "4.1.4.7",
+        "status": "frozen",
+    }
+    assert archived_catalogs["v1"] == {
+        "generation": "v1",
+        "branch": "update/archive-legacy-v1-catalog",
+        "last_supported_framework_version": "4.1.1",
+        "status": "frozen",
+    }
 
 
 def test_in_development_blocks_and_devtools_keep_owner_boundaries() -> None:

--- a/tests/test_project_framework_docs.py
+++ b/tests/test_project_framework_docs.py
@@ -27,7 +27,7 @@ def test_project_framework_docs_publish_topology_first_template_contract(path: s
         "FastAPI",
         "FastMCP",
         "Dynamic Task",
-        "skills/agently/assets/project-template",
+        "skills/agently/assets/full-stack-reference",
     ):
         assert required in document
 
@@ -46,4 +46,9 @@ def test_coding_agent_docs_publish_seven_skill_catalog(path: str) -> None:
     document = _read(path)
 
     assert "`agently-design`" in document
+    assert "`agently-stage`" in document
+    assert "`agently-dynamic-task`" not in document
+    assert "`v3`" in document
+    assert "update/archive-v2-catalog" in document
+    assert "TaskDAG" in document and "DynamicTask" in document
     assert "7 skills" in document or "7 个 skills" in document

--- a/tests/test_workspace_public_docs.py
+++ b/tests/test_workspace_public_docs.py
@@ -120,6 +120,8 @@ def test_skills_docs_define_direct_reconnection_and_thin_facade() -> None:
         assert "AgentExecution" in document
         assert "TaskContext" in document
         assert "Agently.skills_executor" in document
+        assert "TaskDAGContext" in document
+        assert "executor" in document
         assert "run_skills_task" in document
         assert "result-shaped adapter" in document
         assert "skill_activation" not in document


### PR DESCRIPTION
## Summary

- publish the current seven-Skill catalog v3 in the Agently 4.1.4.7 documentation
- keep TaskDAG and DynamicTask as supported low-frequency runtime APIs without a standalone catalog Skill
- update the catalog installation list, archive policy, and full-stack reference path
- record catalog generation v3 and frozen V2/V1 branches in the compatibility development manifest without advancing the framework version
- document the current TaskDAG Skill-resolver compatibility gap instead of presenting direct executor registration as proven

## Version boundary

- package and current release remain 4.1.4.7
- `compatibility/in-development.json` remains on target 4.1.4.7
- no runtime API or release manifest is changed
- 4.1.4.8 catalog alignment will follow the framework version later

## Validation

- compatibility, public-doc, and project-framework tests: 25 passed
- Agently-Skills availability check resolved all seven current Skills
- JSON validation and diff checks passed
